### PR TITLE
Encoding settings compatibility updates

### DIFF
--- a/video_thread.py
+++ b/video_thread.py
@@ -41,11 +41,12 @@ class Worker(QtCore.QObject):
        '-i', '-', # The input comes from a pipe
        '-an',
        '-i', inputFile,
-       '-acodec', "libmp3lame", # output audio codec
+       '-acodec', "libfdk_aac", # output audio codec
+       '-b:a', "192k",
        '-vcodec', "libx264",
-       '-pix_fmt', "yuv444p",
+       '-pix_fmt', "yuv420p",
        '-preset', "medium",
-       '-f', "matroska",
+       '-f', "mp4",
        outputFile],
         stdin=sp.PIPE,stdout=sys.stdout, stderr=sys.stdout)
 


### PR DESCRIPTION
This patch is meant to improve compatibility with hardware players [as well as YouTube](https://support.google.com/youtube/answer/1722171?hl=en) by using AAC, yuv420p & an mp4 container.

With these settings, output works on every device i've been able to test it on, and also fixes compatibility with Quicktime for macs(which only supports YUV planar color space with 4:2:0 chroma subsampling).

Note: This does add the requirement of ffmpeg to be built with --enable-libfdk-aac (as well as --enable-nonfree if using --enable-gpl). The reason for this is that the libfdk_aac encoder produces much better quality audio than the other AAC encoders included in ffmpeg by default and is the recommended encoder as per documentation [here](https://trac.ffmpeg.org/wiki/Encode/AAC) and [here](https://trac.ffmpeg.org/wiki/Encode/HighQualityAudio).