### PR TITLE
Casted slice indices to integer

### DIFF
--- a/core.py
+++ b/core.py
@@ -124,7 +124,7 @@ class Core():
     sample_rate = 44100
     frequencies = numpy.fft.fftfreq(len(spectrum), 1./sample_rate)
 
-    y = abs(spectrum[0:paddedSampleSize/2 - 1])
+    y = abs(spectrum[0:int(paddedSampleSize/2) - 1])
 
     # filter the noise away
     # y[y<80] = 0
@@ -138,6 +138,6 @@ class Core():
     else:
       lastSpectrum = y
 
-    x = frequencies[0:paddedSampleSize/2 - 1]
+    x = frequencies[0:int(paddedSampleSize/2) - 1]
 
     return lastSpectrum


### PR DESCRIPTION
This is a fix for this error:
>TypeError: slice indices must be integers or None or have an \_\_index\_\_ method

which occured with the newest version of Python and the libraries on my Arch setup.