### PR TITLE
Audio mixing

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -9,13 +9,12 @@ import os
 import sys
 
 import core
-import video_thread
 from toolkit import LoadDefaultSettings
 
 
 class Command(QtCore.QObject):
 
-    videoTask = QtCore.pyqtSignal(str, str, list)
+    createVideo = QtCore.pyqtSignal()
 
     def __init__(self):
         QtCore.QObject.__init__(self)
@@ -112,21 +111,16 @@ class Command(QtCore.QObject):
             quit(1)
 
     def createAudioVisualisation(self, input, output):
-        self.videoThread = QtCore.QThread(self)
-        self.videoWorker = video_thread.Worker(self)
-        self.videoWorker.moveToThread(self.videoThread)
-        self.videoWorker.videoCreated.connect(self.videoCreated)
-
-        self.videoThread.start()
-        self.videoTask.emit(
-          input,
-          output,
-          list(reversed(self.core.selectedComponents))
+        self.core.selectedComponents = list(
+            reversed(self.core.selectedComponents))
+        self.core.componentListChanged()
+        self.worker = self.core.newVideoWorker(
+            self, input, output
         )
+        self.worker.videoCreated.connect(self.videoCreated)
+        self.createVideo.emit()
 
     def videoCreated(self):
-        self.videoThread.quit()
-        self.videoThread.wait()
         quit(0)
 
     def showMessage(self, **kwargs):

--- a/src/component.py
+++ b/src/component.py
@@ -27,6 +27,13 @@ class Component(QtCore.QObject):
         # change this number to identify new versions of a component
         return 1
 
+    def properties(self):
+        '''
+            Return a list of properties to signify if your component is
+            non-animated ('static') or returns sound ('audio').
+        '''
+        return []
+
     def cancel(self):
         # please stop any lengthy process in response to this variable
         self.canceled = True
@@ -57,9 +64,6 @@ class Component(QtCore.QObject):
                 self.progressBarSetText = signal to set progress bar text
             Use the latter two signals to update the MainWindow if needed
             for a long initialization procedure (i.e., for a visualizer)
-
-            Return a list of properties to signify if your component is
-            non-animated ('static') or returns sound ('audio').
         '''
         for var, value in kwargs.items():
             exec('self.%s = value' % var)

--- a/src/component.py
+++ b/src/component.py
@@ -30,9 +30,16 @@ class Component(QtCore.QObject):
     def properties(self):
         '''
             Return a list of properties to signify if your component is
-            non-animated ('static') or returns sound ('audio').
+            non-animated ('static'), returns sound ('audio'), or has
+            encountered an error in configuration ('error').
         '''
         return []
+
+    def error(self):
+        '''
+            Return a string containing an error message, or None for a default.
+        '''
+        return
 
     def cancel(self):
         # please stop any lengthy process in response to this variable

--- a/src/component.py
+++ b/src/component.py
@@ -24,7 +24,9 @@ class Component(QtCore.QObject):
         return self.__doc__
 
     def version(self):
-        # change this number to identify new versions of a component
+        '''
+            Change this number to identify new versions of a component
+        '''
         return 1
 
     def properties(self):
@@ -42,15 +44,22 @@ class Component(QtCore.QObject):
         return
 
     def cancel(self):
-        # please stop any lengthy process in response to this variable
+        '''
+            Stop any lengthy process in response to this variable
+        '''
         self.canceled = True
 
     def reset(self):
         self.canceled = False
 
     def update(self):
-        self.modified.emit(self.compPos, self.savePreset())
-        # read your widget values, then call super().update()
+        '''
+            Read your widget values from self.page, then call super().update()
+        '''
+        self.parent.drawPreview()
+        saveValueStore = self.savePreset()
+        saveValueStore['preset'] = self.currentPreset
+        self.modified.emit(self.compPos, saveValueStore)
 
     def loadPreset(self, presetDict, presetName):
         '''
@@ -72,8 +81,8 @@ class Component(QtCore.QObject):
             Use the latter two signals to update the MainWindow if needed
             for a long initialization procedure (i.e., for a visualizer)
         '''
-        for var, value in kwargs.items():
-            exec('self.%s = value' % var)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def command(self, arg):
         '''
@@ -143,15 +152,10 @@ class Component(QtCore.QObject):
 
     def widget(self, parent):
         self.parent = parent
-        page = uic.loadUi(os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), 'example.ui'))
+        page = self.loadUi('example.ui')
         # --- connect widget signals here ---
         self.page = page
         return page
-
-    def update(self):
-        self.parent.drawPreview()
-        super().update()
 
     def previewRender(self, previewWorker):
         width = int(previewWorker.core.settings.value('outputWidth'))
@@ -170,8 +174,12 @@ class Component(QtCore.QObject):
 
     def audio(self):
         \'''
-            Return audio to mix into master as a string (path to audio file),
-            or an object that returns raw audio data [future feature].
+            Return audio to mix into master as a tuple with two elements:
+            The first element can be:
+                - A string (path to audio file),
+                - Or an object that returns audio data through a pipe
+            The second element must be a dictionary of ffmpeg parameters
+            to apply to the input stream.
         \'''
 
     @classmethod

--- a/src/component.py
+++ b/src/component.py
@@ -48,14 +48,18 @@ class Component(QtCore.QObject):
             if presetName is not None else presetDict['preset']
 
     def preFrameRender(self, **kwargs):
-        ''' Triggered only before a video is exported (video_thread.py)
+        '''
+            Triggered only before a video is exported (video_thread.py)
                 self.worker = the video thread worker
                 self.completeAudioArray = a list of audio samples
                 self.sampleSize = number of audio samples per video frame
                 self.progressBarUpdate = signal to set progress bar number
                 self.progressBarSetText = signal to set progress bar text
-                Use the latter two signals to update the MainWindow if needed
+            Use the latter two signals to update the MainWindow if needed
             for a long initialization procedure (i.e., for a visualizer)
+
+            Return a list of properties to signify if your component is
+            non-animated ('static') or returns sound ('audio').
         '''
         for var, value in kwargs.items():
             exec('self.%s = value' % var)
@@ -135,8 +139,8 @@ class Component(QtCore.QObject):
         return page
 
     def update(self):
-        super().update()
         self.parent.drawPreview()
+        super().update()
 
     def previewRender(self, previewWorker):
         width = int(previewWorker.core.settings.value('outputWidth'))
@@ -153,9 +157,17 @@ class Component(QtCore.QObject):
         image = BlankFrame(width, height)
         return image
 
+    def audio(self):
+        \'''
+            Return audio to mix into master as a string (path to audio file),
+            or an object that returns raw audio data [future feature].
+        \'''
+
     @classmethod
     def names(cls):
-        # Alternative names for renaming a component between project files
+        \'''
+            Alternative names for renaming a component between project files.
+        \'''
         return []
     '''
 

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -15,6 +15,7 @@ class Component(Component):
 
     def widget(self, parent):
         self.parent = parent
+        self.settings = self.parent.core.settings
         page = self.loadUi('color.ui')
 
         self.color1 = (0, 0, 0)
@@ -42,9 +43,9 @@ class Component(Component):
         page.spinBox_x.valueChanged.connect(self.update)
         page.spinBox_y.valueChanged.connect(self.update)
         page.spinBox_width.setValue(
-            int(parent.settings.value("outputWidth")))
+            int(self.settings.value("outputWidth")))
         page.spinBox_height.setValue(
-            int(parent.settings.value("outputHeight")))
+            int(self.settings.value("outputHeight")))
 
         page.lineEdit_color1.textChanged.connect(self.update)
         page.lineEdit_color2.textChanged.connect(self.update)
@@ -113,16 +114,16 @@ class Component(Component):
         super().update()
 
     def previewRender(self, previewWorker):
-        width = int(previewWorker.core.settings.value('outputWidth'))
-        height = int(previewWorker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
     def properties(self):
         return ['static']
 
     def frameRender(self, layerNo, frameNo):
-        width = int(self.worker.core.settings.value('outputWidth'))
-        height = int(self.worker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
     def drawFrame(self, width, height):

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -110,7 +110,6 @@ class Component(Component):
             self.page.pushButton_color2.setEnabled(False)
         self.page.fillWidget.setCurrentIndex(self.fillType)
 
-        self.parent.drawPreview()
         super().update()
 
     def previewRender(self, previewWorker):

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -117,8 +117,7 @@ class Component(Component):
         height = int(previewWorker.core.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
-    def preFrameRender(self, **kwargs):
-        super().preFrameRender(**kwargs)
+    def properties(self):
         return ['static']
 
     def frameRender(self, layerNo, frameNo):

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -38,7 +38,7 @@ class Component(Component):
         self.yPosition = self.page.spinBox_y.value()
         self.stretched = self.page.checkBox_stretch.isChecked()
         self.mirror = self.page.checkBox_mirror.isChecked()
-        self.parent.drawPreview()
+
         super().update()
 
     def previewRender(self, previewWorker):

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -13,7 +13,7 @@ class Component(Component):
 
     def widget(self, parent):
         self.parent = parent
-        self.settings = parent.settings
+        self.settings = self.parent.core.settings
         page = self.loadUi('image.ui')
 
         page.lineEdit_image.textChanged.connect(self.update)
@@ -42,24 +42,24 @@ class Component(Component):
         super().update()
 
     def previewRender(self, previewWorker):
-        width = int(previewWorker.core.settings.value('outputWidth'))
-        height = int(previewWorker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
     def properties(self):
         props = ['static']
-        if not os.path.exists(self.imagePath):
+        if self.imagePath and not os.path.exists(self.imagePath):
             props.append('error')
         return props
 
     def error(self):
         if not os.path.exists(self.imagePath):
-            return "The image path selected on " \
-                "layer %s no longer exists!" % str(self.compPos)
+            return "The image selected on " \
+                "layer %s does not exist!" % str(self.compPos)
 
     def frameRender(self, layerNo, frameNo):
-        width = int(self.worker.core.settings.value('outputWidth'))
-        height = int(self.worker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
     def drawFrame(self, width, height):

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -47,7 +47,15 @@ class Component(Component):
         return self.drawFrame(width, height)
 
     def properties(self):
-        return ['static']
+        props = ['static']
+        if not os.path.exists(self.imagePath):
+            props.append('error')
+        return props
+
+    def error(self):
+        if not os.path.exists(self.imagePath):
+            return "The image path selected on " \
+                "layer %s no longer exists!" % str(self.compPos)
 
     def frameRender(self, layerNo, frameNo):
         width = int(self.worker.core.settings.value('outputWidth'))

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -48,14 +48,15 @@ class Component(Component):
 
     def properties(self):
         props = ['static']
-        if self.imagePath and not os.path.exists(self.imagePath):
+        if not os.path.exists(self.imagePath):
             props.append('error')
         return props
 
     def error(self):
+        if not self.imagePath:
+            return "There is no image selected."
         if not os.path.exists(self.imagePath):
-            return "The image selected on " \
-                "layer %s does not exist!" % str(self.compPos)
+            return "The image selected does not exist!"
 
     def frameRender(self, layerNo, frameNo):
         width = int(self.settings.value('outputWidth'))

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -42,7 +42,6 @@ class Component(Component):
         super().update()
 
     def previewRender(self, previewWorker):
-        self.imageFormats = previewWorker.core.imageFormats
         width = int(previewWorker.core.settings.value('outputWidth'))
         height = int(previewWorker.core.settings.value('outputHeight'))
         return self.drawFrame(width, height)
@@ -110,7 +109,7 @@ class Component(Component):
         imgDir = self.settings.value("componentDir", os.path.expanduser("~"))
         filename, _ = QtWidgets.QFileDialog.getOpenFileName(
             self.page, "Choose Image", imgDir,
-            "Image Files (%s)" % " ".join(self.imageFormats))
+            "Image Files (%s)" % " ".join(self.core.imageFormats))
         if filename:
             self.settings.setValue("componentDir", os.path.dirname(filename))
             self.page.lineEdit_image.setText(filename)

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -46,8 +46,7 @@ class Component(Component):
         height = int(previewWorker.core.settings.value('outputHeight'))
         return self.drawFrame(width, height)
 
-    def preFrameRender(self, **kwargs):
-        super().preFrameRender(**kwargs)
+    def properties(self):
         return ['static']
 
     def frameRender(self, layerNo, frameNo):

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -21,6 +21,7 @@ class Component(Component):
 
     def widget(self, parent):
         self.parent = parent
+        self.settings = self.parent.core.settings
         self.visColor = (255, 255, 255)
         self.scale = 20
         self.y = 0
@@ -76,8 +77,8 @@ class Component(Component):
     def previewRender(self, previewWorker):
         spectrum = numpy.fromfunction(
             lambda x: float(self.scale)/2500*(x-128)**2, (255,), dtype="int16")
-        width = int(previewWorker.core.settings.value('outputWidth'))
-        height = int(previewWorker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.drawBars(
             width, height, spectrum, self.visColor, self.layout
         )
@@ -88,8 +89,8 @@ class Component(Component):
         self.smoothConstantUp = 0.8
         self.lastSpectrum = None
         self.spectrumArray = {}
-        self.width = int(self.worker.core.settings.value('outputWidth'))
-        self.height = int(self.worker.core.settings.value('outputHeight'))
+        self.width = int(self.settings.value('outputWidth'))
+        self.height = int(self.settings.value('outputHeight'))
 
         for i in range(0, len(self.completeAudioArray), self.sampleSize):
             if self.canceled:

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -51,7 +51,7 @@ class Component(Component):
         self.visColor = self.RGBFromString(self.page.lineEdit_visColor.text())
         self.scale = self.page.spinBox_scale.value()
         self.y = self.page.spinBox_y.value()
-        self.parent.drawPreview()
+
         super().update()
 
     def loadPreset(self, pr, presetName=None):

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -79,6 +79,11 @@ class Component(Component):
         if not arg.startswith('preset=') and '=' in arg:
             key, arg = arg.split('=', 1)
             if key == 'path':
+                if '*%s' % os.path.splitext(arg)[1] \
+                        not in self.core.audioFormats:
+                    print("Not a supported audio format")
+                    quit(1)
                 self.page.lineEdit_sound.setText(arg)
                 return
+
         super().command(arg)

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -34,7 +34,16 @@ class Component(Component):
         pass
 
     def properties(self):
-        return ['static', 'audio']
+        props = ['static', 'audio']
+        if not os.path.exists(self.sound):
+            props.append('error')
+        return props
+
+    def error(self):
+        if not self.sound:
+            return "No audio file selected."
+        if not os.path.exists(self.sound):
+            return "The audio file selected no longer exists!"
 
     def audio(self):
         return (self.sound, {})

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -31,7 +31,9 @@ class Component(Component):
         return self.frameRender(self.compPos, 0)
 
     def preFrameRender(self, **kwargs):
-        # super().preFrameRender(**kwargs)
+        pass
+
+    def properties(self):
         return ['static', 'audio']
 
     def audio(self):

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -1,0 +1,74 @@
+from PyQt5 import QtGui, QtCore, QtWidgets
+import os
+
+from component import Component
+from frame import BlankFrame
+
+
+class Component(Component):
+    '''Sound'''
+
+    modified = QtCore.pyqtSignal(int, dict)
+
+    def widget(self, parent):
+        self.parent = parent
+        self.settings = parent.settings
+        page = self.loadUi('sound.ui')
+
+        page.lineEdit_sound.textChanged.connect(self.update)
+        page.pushButton_sound.clicked.connect(self.pickSound)
+
+        self.page = page
+        return page
+
+    def update(self):
+        self.sound = self.page.lineEdit_sound.text()
+        super().update()
+
+    def previewRender(self, previewWorker):
+        width = int(previewWorker.core.settings.value('outputWidth'))
+        height = int(previewWorker.core.settings.value('outputHeight'))
+        return self.frameRender(self.compPos, 0)
+
+    def preFrameRender(self, **kwargs):
+        # super().preFrameRender(**kwargs)
+        return ['static', 'audio']
+
+    def audio(self):
+        return self.sound
+
+    def pickSound(self):
+        sndDir = self.settings.value("componentDir", os.path.expanduser("~"))
+        filename, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self.page, "Choose Sound", sndDir,
+            "Audio Files (%s)" % " ".join(self.core.audioFormats))
+        if filename:
+            self.settings.setValue("componentDir", os.path.dirname(filename))
+            self.page.lineEdit_sound.setText(filename)
+            self.update()
+
+    def frameRender(self, layerNo, frameNo):
+        width = int(self.core.settings.value('outputWidth'))
+        height = int(self.core.settings.value('outputHeight'))
+        return BlankFrame(width, height)
+
+    def loadPreset(self, pr, presetName=None):
+        super().loadPreset(pr, presetName)
+        self.page.lineEdit_sound.setText(pr['sound'])
+
+    def savePreset(self):
+        return {
+            'preset': self.currentPreset,
+            'sound': self.sound,
+        }
+
+    def commandHelp(self):
+        print('Path to audio file:\n    path=/filepath/to/sound.ogg')
+
+    def command(self, arg):
+        if not arg.startswith('preset=') and '=' in arg:
+            key, arg = arg.split('=', 1)
+            if key == 'path':
+                self.page.lineEdit_sound.setText(arg)
+                return
+        super().command(arg)

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -69,7 +69,6 @@ class Component(Component):
 
     def savePreset(self):
         return {
-            'preset': self.currentPreset,
             'sound': self.sound,
         }
 

--- a/src/components/sound.py
+++ b/src/components/sound.py
@@ -28,7 +28,7 @@ class Component(Component):
     def previewRender(self, previewWorker):
         width = int(previewWorker.core.settings.value('outputWidth'))
         height = int(previewWorker.core.settings.value('outputHeight'))
-        return self.frameRender(self.compPos, 0)
+        return BlankFrame(width, height)
 
     def preFrameRender(self, **kwargs):
         pass
@@ -37,7 +37,7 @@ class Component(Component):
         return ['static', 'audio']
 
     def audio(self):
-        return self.sound
+        return (self.sound, {})
 
     def pickSound(self):
         sndDir = self.settings.value("componentDir", os.path.expanduser("~"))
@@ -50,8 +50,8 @@ class Component(Component):
             self.update()
 
     def frameRender(self, layerNo, frameNo):
-        width = int(self.core.settings.value('outputWidth'))
-        height = int(self.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return BlankFrame(width, height)
 
     def loadPreset(self, pr, presetName=None):

--- a/src/components/sound.ui
+++ b/src/components/sound.ui
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>197</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <widget class="QLabel" name="label_textColor">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>31</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Audio File</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit_sound">
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_sound">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>1</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>...</string>
+         </property>
+         <property name="MaximumSize" stdset="0">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -121,7 +121,13 @@ class Component(Component):
         return self.addText(width, height)
 
     def properties(self):
-        return ['static']
+        props = ['static']
+        if not self.title:
+            props.append('error')
+        return props
+
+    def error(self):
+        return "No text provided."
 
     def frameRender(self, layerNo, frameNo):
         width = int(self.settings.value('outputWidth'))

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -69,7 +69,7 @@ class Component(Component):
         btnStyle = "QPushButton { background-color : %s; outline: none; }" \
             % QColor(*self.textColor).name()
         self.page.pushButton_textColor.setStyleSheet(btnStyle)
-        self.parent.drawPreview()
+
         super().update()
 
     def getXY(self):

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -119,8 +119,7 @@ class Component(Component):
         height = int(previewWorker.core.settings.value('outputHeight'))
         return self.addText(width, height)
 
-    def preFrameRender(self, **kwargs):
-        super().preFrameRender(**kwargs)
+    def properties(self):
         return ['static']
 
     def frameRender(self, layerNo, frameNo):

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -75,15 +75,15 @@ class Component(Component):
         '''Returns true x, y after considering alignment settings'''
         fm = QtGui.QFontMetrics(self.titleFont)
         if self.alignment == 0:             # Left
-            x = self.xPosition
+            x = int(self.xPosition)
 
         if self.alignment == 1:             # Middle
             offset = fm.width(self.title)/2
-            x = self.xPosition - offset
+            x = int(self.xPosition - offset)
 
         if self.alignment == 2:             # Right
             offset = fm.width(self.title)
-            x = self.xPosition - offset
+            x = int(self.xPosition - offset)
         return x, self.yPosition
 
     def loadPreset(self, pr, presetName=None):
@@ -128,12 +128,12 @@ class Component(Component):
         return self.addText(width, height)
 
     def addText(self, width, height):
-        x, y = self.getXY()
-        image = FramePainter(width, height)
 
+        image = FramePainter(width, height)
         self.titleFont.setPixelSize(self.fontSize)
         image.setFont(self.titleFont)
         image.setPen(self.textColor)
+        x, y = self.getXY()
         image.drawText(x, y, self.title)
 
         return image.finalize()

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -17,10 +17,11 @@ class Component(Component):
         self.titleFont = QFont()
 
     def widget(self, parent):
-        height = int(parent.settings.value('outputHeight'))
-        width = int(parent.settings.value('outputWidth'))
-
         self.parent = parent
+        self.settings = self.parent.core.settings
+        height = int(self.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+
         self.textColor = (255, 255, 255)
         self.title = 'Text'
         self.alignment = 1
@@ -78,12 +79,12 @@ class Component(Component):
             x = int(self.xPosition)
 
         if self.alignment == 1:             # Middle
-            offset = fm.width(self.title)/2
-            x = int(self.xPosition - offset)
+            offset = int(fm.width(self.title)/2)
+            x = self.xPosition - offset
 
         if self.alignment == 2:             # Right
             offset = fm.width(self.title)
-            x = int(self.xPosition - offset)
+            x = self.xPosition - offset
         return x, self.yPosition
 
     def loadPreset(self, pr, presetName=None):
@@ -115,16 +116,16 @@ class Component(Component):
         }
 
     def previewRender(self, previewWorker):
-        width = int(previewWorker.core.settings.value('outputWidth'))
-        height = int(previewWorker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.addText(width, height)
 
     def properties(self):
         return ['static']
 
     def frameRender(self, layerNo, frameNo):
-        width = int(self.worker.core.settings.value('outputWidth'))
-        height = int(self.worker.core.settings.value('outputHeight'))
+        width = int(self.settings.value('outputWidth'))
+        height = int(self.settings.value('outputHeight'))
         return self.addText(width, height)
 
     def addText(self, width, height):

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -158,14 +158,14 @@ class Component(Component):
         if self.useAudio:
             # props.append('audio')
             pass
-        if not os.path.exists(self.videoPath):
+        if self.videoPath and not os.path.exists(self.videoPath):
             props.append('error')
         return props
 
     def error(self):
         if not os.path.exists(self.videoPath):
-            return "The video path selected on " \
-                "layer %s no longer exists!" % str(self.compPos)
+            return "The video selected on " \
+                "layer %s does not exist!" % str(self.compPos)
 
     def audio(self):
         return (self.videoPath, {})

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -115,6 +115,7 @@ class Component(Component):
         self.settings = parent.settings
         page = self.loadUi('video.ui')
         self.videoPath = ''
+        self.badVideo = False
         self.x = 0
         self.y = 0
         self.loopVideo = False
@@ -156,14 +157,18 @@ class Component(Component):
         props = []
         if self.useAudio:
             props.append('audio')
-        if self.videoPath and not os.path.exists(self.videoPath):
+        if not self.videoPath or self.badVideo \
+                or not os.path.exists(self.videoPath):
             props.append('error')
         return props
 
     def error(self):
+        if not self.videoPath:
+            return "There is no video selected."
         if not os.path.exists(self.videoPath):
-            return "The video selected on " \
-                "layer %s does not exist!" % str(self.compPos)
+            return "The video selected does not exist!"
+        if self.badVideo:
+            return "The video selected is corrupt!"
 
     def audio(self):
         return (self.videoPath, {'map': '-v'})
@@ -300,6 +305,7 @@ def finalizeFrame(self, imageData, width, height):
             '### BAD VIDEO SELECTED ###\n'
             'Video will not export with these settings'
         )
+        self.badVideo = True
         return BlankFrame(width, height)
 
     if self.scale != 100 \
@@ -308,4 +314,5 @@ def finalizeFrame(self, imageData, width, height):
         frame.paste(image, box=(self.xPosition, self.yPosition))
     else:
         frame = image
+    self.badVideo = False
     return frame

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -143,7 +143,6 @@ class Component(Component):
         super().update()
 
     def previewRender(self, previewWorker):
-        self.videoFormats = previewWorker.core.videoFormats
         width = int(previewWorker.core.settings.value('outputWidth'))
         height = int(previewWorker.core.settings.value('outputHeight'))
         self.updateChunksize(width, height)
@@ -156,8 +155,7 @@ class Component(Component):
     def properties(self):
         props = []
         if self.useAudio:
-            # props.append('audio')
-            pass
+            props.append('audio')
         if self.videoPath and not os.path.exists(self.videoPath):
             props.append('error')
         return props
@@ -168,7 +166,7 @@ class Component(Component):
                 "layer %s does not exist!" % str(self.compPos)
 
     def audio(self):
-        return (self.videoPath, {})
+        return (self.videoPath, {'map': '-v'})
 
     def preFrameRender(self, **kwargs):
         super().preFrameRender(**kwargs)
@@ -216,7 +214,7 @@ class Component(Component):
         imgDir = self.settings.value("componentDir", os.path.expanduser("~"))
         filename, _ = QtWidgets.QFileDialog.getOpenFileName(
             self.page, "Choose Video",
-            imgDir, "Video Files (%s)" % " ".join(self.videoFormats)
+            imgDir, "Video Files (%s)" % " ".join(self.core.videoFormats)
         )
         if filename:
             self.settings.setValue("componentDir", os.path.dirname(filename))

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -140,7 +140,7 @@ class Component(Component):
         self.scale = self.page.spinBox_scale.value()
         self.xPosition = self.page.spinBox_x.value()
         self.yPosition = self.page.spinBox_y.value()
-        self.parent.drawPreview()
+
         super().update()
 
     def previewRender(self, previewWorker):

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -123,6 +123,7 @@ class Component(Component):
         page.pushButton_video.clicked.connect(self.pickVideo)
         page.checkBox_loop.stateChanged.connect(self.update)
         page.checkBox_distort.stateChanged.connect(self.update)
+        page.checkBox_useAudio.stateChanged.connect(self.update)
         page.spinBox_scale.valueChanged.connect(self.update)
         page.spinBox_x.valueChanged.connect(self.update)
         page.spinBox_y.valueChanged.connect(self.update)
@@ -133,6 +134,7 @@ class Component(Component):
     def update(self):
         self.videoPath = self.page.lineEdit_video.text()
         self.loopVideo = self.page.checkBox_loop.isChecked()
+        self.useAudio = self.page.checkBox_useAudio.isChecked()
         self.distort = self.page.checkBox_distort.isChecked()
         self.scale = self.page.spinBox_scale.value()
         self.xPosition = self.page.spinBox_x.value()
@@ -150,6 +152,23 @@ class Component(Component):
             return BlankFrame(width, height)
         else:
             return frame
+
+    def properties(self):
+        props = []
+        if self.useAudio:
+            # props.append('audio')
+            pass
+        if not os.path.exists(self.videoPath):
+            props.append('error')
+        return props
+
+    def error(self):
+        if not os.path.exists(self.videoPath):
+            return "The video path selected on " \
+                "layer %s no longer exists!" % str(self.compPos)
+
+    def audio(self):
+        return (self.videoPath, {})
 
     def preFrameRender(self, **kwargs):
         super().preFrameRender(**kwargs)
@@ -175,6 +194,7 @@ class Component(Component):
         super().loadPreset(pr, presetName)
         self.page.lineEdit_video.setText(pr['video'])
         self.page.checkBox_loop.setChecked(pr['loop'])
+        self.page.checkBox_useAudio.setChecked(pr['useAudio'])
         self.page.checkBox_distort.setChecked(pr['distort'])
         self.page.spinBox_scale.setValue(pr['scale'])
         self.page.spinBox_x.setValue(pr['x'])
@@ -185,6 +205,7 @@ class Component(Component):
             'preset': self.currentPreset,
             'video': self.videoPath,
             'loop': self.loopVideo,
+            'useAudio': self.useAudio,
             'distort': self.distort,
             'scale': self.scale,
             'x': self.xPosition,

--- a/src/components/video.ui
+++ b/src/components/video.ui
@@ -190,16 +190,20 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer_10">
+      <widget class="QCheckBox" name="checkBox_useAudio">
+       <property name="text">
+        <string>Use Audio</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>5</width>
+         <width>40</width>
          <height>20</height>
         </size>
        </property>
@@ -255,9 +259,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QWidget" name="widget" native="true"/>
    </item>
   </layout>
  </widget>

--- a/src/core.py
+++ b/src/core.py
@@ -524,7 +524,7 @@ class Core:
             if 'audio' in comp.properties()
         ]
         if extraAudio:
-            for extraInputFile in extraAudio:
+            for extraInputFile, params in extraAudio:
                 ffmpegCommand.extend([
                     '-i', extraInputFile
                 ])
@@ -532,7 +532,7 @@ class Core:
                 '-filter_complex',
                 'amix=inputs=%s:duration=longest:dropout_transition=3' % str(
                     len(extraAudio) + 1
-                )
+                ),
             ])
 
         ffmpegCommand.extend([

--- a/src/core.py
+++ b/src/core.py
@@ -414,6 +414,7 @@ class Core:
                 f.write('[Components]\n')
                 for comp in self.selectedComponents:
                     saveValueStore = comp.savePreset()
+                    saveValueStore['preset'] = comp.currentPreset
                     f.write('%s\n' % str(comp))
                     f.write('%s\n' % str(comp.version()))
                     f.write('%s\n' % toolkit.presetToString(saveValueStore))

--- a/src/core.py
+++ b/src/core.py
@@ -527,20 +527,20 @@ class Core:
         ]
         if extraAudio:
             unwantedVideoStreams = []
-            for compNo, params in enumerate(extraAudio):
+            for streamNo, params in enumerate(extraAudio):
                 extraInputFile, params = params
                 ffmpegCommand.extend([
                     '-i', extraInputFile
                 ])
                 if 'map' in params and params['map'] == '-v':
                     # a video stream to remove
-                    unwantedVideoStreams.append(compNo + 1)
+                    unwantedVideoStreams.append(streamNo + 1)
 
             if unwantedVideoStreams:
                 ffmpegCommand.extend(['-map', '0'])
-            for compNo in unwantedVideoStreams:
+            for streamNo in unwantedVideoStreams:
                 ffmpegCommand.extend([
-                    '-map', '-%s:v' % str(compNo)
+                    '-map', '-%s:v' % str(streamNo)
                 ])
             ffmpegCommand.extend([
                 '-filter_complex',

--- a/src/core.py
+++ b/src/core.py
@@ -485,7 +485,8 @@ class Core:
             '-ac', '1',  # mono (set to '2' for stereo)
             '-']
         in_pipe = toolkit.openPipe(
-            command, stdout=sp.PIPE, stderr=sp.DEVNULL, bufsize=10**8)
+            command, stdout=sp.PIPE, stderr=sp.DEVNULL, bufsize=10**8
+        )
 
         completeAudioArray = numpy.empty(0, dtype="int16")
 
@@ -495,7 +496,7 @@ class Core:
             if self.canceled:
                 break
             # read 2 seconds of audio
-            progress = progress + 4
+            progress += 4
             raw_audio = in_pipe.stdout.read(88200*4)
             if len(raw_audio) == 0:
                 break

--- a/src/core.py
+++ b/src/core.py
@@ -12,6 +12,7 @@ from PyQt5.QtCore import QStandardPaths
 
 import toolkit
 from frame import Frame
+import video_thread
 
 
 class Core:
@@ -632,6 +633,21 @@ class Core:
         completeAudioArray = completeAudioArrayCopy
 
         return completeAudioArray
+
+    def newVideoWorker(self, loader, audioFile, outputPath):
+        self.videoThread = QtCore.QThread(loader)
+        videoWorker = video_thread.Worker(
+            loader, audioFile, outputPath, self.selectedComponents
+        )
+        videoWorker.moveToThread(self.videoThread)
+        videoWorker.videoCreated.connect(self.videoCreated)
+
+        self.videoThread.start()
+        return videoWorker
+
+    def videoCreated(self):
+        self.videoThread.quit()
+        self.videoThread.wait()
 
     def cancel(self):
         self.canceled = True

--- a/src/core.py
+++ b/src/core.py
@@ -526,13 +526,25 @@ class Core:
             if 'audio' in comp.properties()
         ]
         if extraAudio:
-            for extraInputFile, params in extraAudio:
+            unwantedVideoStreams = []
+            for compNo, params in enumerate(extraAudio):
+                extraInputFile, params = params
                 ffmpegCommand.extend([
                     '-i', extraInputFile
                 ])
+                if 'map' in params and params['map'] == '-v':
+                    # a video stream to remove
+                    unwantedVideoStreams.append(compNo + 1)
+
+            if unwantedVideoStreams:
+                ffmpegCommand.extend(['-map', '0'])
+            for compNo in unwantedVideoStreams:
+                ffmpegCommand.extend([
+                    '-map', '-%s:v' % str(compNo)
+                ])
             ffmpegCommand.extend([
                 '-filter_complex',
-                'amix=inputs=%s:duration=longest:dropout_transition=3' % str(
+                'amix=inputs=%s:duration=first:dropout_transition=3' % str(
                     len(extraAudio) + 1
                 ),
             ])

--- a/src/core.py
+++ b/src/core.py
@@ -464,10 +464,11 @@ class Core:
                 except sp.CalledProcessError:
                     return "avconv"
 
-    def createFfmpegCommand(self, inputFile, outputFile):
+    def createFfmpegCommand(self, inputFile, outputFile, duration):
         '''
             Constructs the major ffmpeg command used to export the video
         '''
+        duration = str(duration)
 
         # Test if user has libfdk_aac
         encoders = toolkit.checkOutput(
@@ -516,10 +517,12 @@ class Core:
             ),
             '-pix_fmt', 'rgba',
             '-r', self.settings.value('outputFrameRate'),
+            '-t', duration,
             '-i', '-',  # the video input comes from a pipe
             '-an',  # the video input has no sound
 
             # INPUT SOUND
+            '-t', duration,
             '-i', inputFile
         ]
 
@@ -532,6 +535,7 @@ class Core:
             for streamNo, params in enumerate(extraAudio):
                 extraInputFile, params = params
                 ffmpegCommand.extend([
+                    '-t', duration,
                     '-i', extraInputFile
                 ])
                 if 'map' in params and params['map'] == '-v':
@@ -632,7 +636,7 @@ class Core:
         completeAudioArrayCopy[:len(completeAudioArray)] = completeAudioArray
         completeAudioArray = completeAudioArrayCopy
 
-        return completeAudioArray
+        return (completeAudioArray, duration)
 
     def newVideoWorker(self, loader, audioFile, outputPath):
         self.videoThread = QtCore.QThread(loader)

--- a/src/core.py
+++ b/src/core.py
@@ -11,6 +11,7 @@ from importlib import import_module
 from PyQt5.QtCore import QStandardPaths
 
 import toolkit
+from frame import Frame
 
 
 class Core:
@@ -20,6 +21,7 @@ class Core:
         opens projects and presets, and stores settings/paths to data.
     '''
     def __init__(self):
+        Frame.core = self
         self.dataDir = QStandardPaths.writableLocation(
             QStandardPaths.AppConfigLocation
         )

--- a/src/frame.py
+++ b/src/frame.py
@@ -14,7 +14,7 @@ class FramePainter(QtGui.QPainter):
     '''
     def __init__(self, width, height):
         image = BlankFrame(width, height)
-        self.image = ImageQt(image)
+        self.image = QtGui.QImage(ImageQt(image))
         super().__init__(self.image)
 
     def setPen(self, RgbTuple):

--- a/src/frame.py
+++ b/src/frame.py
@@ -5,6 +5,11 @@ from PyQt5 import QtGui
 from PIL import Image
 from PIL.ImageQt import ImageQt
 import sys
+import os
+
+
+class Frame:
+    '''Controller class for all frames.'''
 
 
 class FramePainter(QtGui.QPainter):
@@ -43,5 +48,19 @@ def FloodFrame(width, height, RgbaTuple):
 
 
 def BlankFrame(width, height):
-    '''The base frame used by each component to start drawing'''
+    '''The base frame used by each component to start drawing.'''
     return FloodFrame(width, height, (0, 0, 0, 0))
+
+
+def Checkerboard(width, height):
+    '''
+        A checkerboard to represent transparency to the user.
+        TODO: Would be cool to generate this image with numpy instead.
+    '''
+    image = FloodFrame(1920, 1080, (0, 0, 0, 0))
+    image.paste(Image.open(
+        os.path.join(Frame.core.wd, "background.png")),
+        (0, 0)
+    )
+    image = image.resize((width, height))
+    return image

--- a/src/main.py
+++ b/src/main.py
@@ -8,13 +8,13 @@ import video_thread
 
 
 if __name__ == "__main__":
-    mode = 'gui'
+    mode = 'GUI'
     if len(sys.argv) > 2:
-        mode = 'cmd'
+        mode = 'commandline'
 
     elif len(sys.argv) == 2:
         if sys.argv[1].startswith('-'):
-            mode = 'cmd'
+            mode = 'commandline'
         else:
             # opening a project file with gui
             proj = sys.argv[1]
@@ -22,16 +22,17 @@ if __name__ == "__main__":
         # normal gui launch
         proj = None
 
+    print('Starting Audio Visualizer in %s mode' % mode)
     app = QtWidgets.QApplication(sys.argv)
     app.setApplicationName("audio-visualizer")
     # app.setOrganizationName("audio-visualizer")
 
-    if mode == 'cmd':
+    if mode == 'commandline':
         from command import *
 
         main = Command()
 
-    elif mode == 'gui':
+    elif mode == 'GUI':
         from mainwindow import *
         import atexit
         import signal

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -713,6 +713,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def saveCurrentProject(self):
         if self.currentProject:
             self.core.createProjectFile(self.currentProject, self.window)
+            try:
+                os.remove(self.autosavePath)
+            except FileNotFoundError:
+                pass
             self.updateWindowTitle()
         else:
             self.openSaveProjectDialog()

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -306,6 +306,7 @@ class MainWindow(QtWidgets.QMainWindow):
         QtWidgets.QShortcut("Ctrl+A", self.window, self.openSaveProjectDialog)
         QtWidgets.QShortcut("Ctrl+O", self.window, self.openOpenProjectDialog)
         QtWidgets.QShortcut("Ctrl+N", self.window, self.createNewProject)
+        QtWidgets.QShortcut("Ctrl+Alt+Shift+R", self.window, self.drawPreview)
 
         QtWidgets.QShortcut(
             "Ctrl+T", self.window,
@@ -585,6 +586,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.autosave(force)
         self.updateWindowTitle()
 
+    @QtCore.pyqtSlot(QtGui.QImage)
     def showPreviewImage(self, image):
         self.previewWindow.changePixmap(image)
 

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -557,9 +557,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.window.progressLabel.setHidden(True)
             self.drawPreview(True)
 
+    @QtCore.pyqtSlot(int)
     def progressBarUpdated(self, value):
         self.window.progressBar_createVideo.setValue(value)
 
+    @QtCore.pyqtSlot(str)
     def progressBarSetText(self, value):
         if sys.platform == 'darwin':
             self.window.progressLabel.setText(value)

--- a/src/presetmanager.py
+++ b/src/presetmanager.py
@@ -160,6 +160,7 @@ class PresetManager(QtWidgets.QDialog):
                         selectedComponents[index].currentPreset = newName
                         saveValueStore = \
                             selectedComponents[index].savePreset()
+                        saveValueStore['preset'] = newName
                         componentName = str(selectedComponents[index]).strip()
                         vers = selectedComponents[index].version()
                         self.createNewPreset(

--- a/src/preview_thread.py
+++ b/src/preview_thread.py
@@ -69,10 +69,13 @@ class Worker(QtCore.QObject):
                             str(component),
                         detail=str(e),
                         icon='Warning',
-                        parent=None  # mainwindow is in a different thread
+                        parent=None  # MainWindow is in a different thread
                     )
-                    from frame import BlankFrame
-                    self.imageCreated.emit(ImageQt(BlankFrame))
+                    self.imageCreated.emit(
+                        QtGui.QImage(ImageQt(
+                            FloodFrame(width, height, (0, 0, 0, 0))
+                        ))
+                    )
                     self.error.emit()
                     break
             else:

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -151,6 +151,15 @@ class Worker(QtCore.QObject):
                 progressBarSetText=self.progressBarSetText
             )
 
+            if 'error' in comp.properties():
+                self.canceled = True
+                errMsg = "Component #%s encountered an error!" % compNo \
+                    if comp.error() is None else comp.error()
+                self.parent.showMessage(
+                        msg=errMsg,
+                        icon='Warning',
+                        parent=None  # MainWindow is in a different thread
+                    )
             if 'static' in comp.properties():
                 self.staticComponents[compNo] = \
                     comp.frameRender(compNo, 0).copy()

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -54,18 +54,18 @@ class Worker(QtCore.QObject):
             audioI = self.compositeQueue.get()
             bgI = int(audioI / self.sampleSize)
             frame = None
-
             for compNo, comp in reversed(list(enumerate(self.components))):
-                if compNo in self.staticComponents:
-                    if self.staticComponents[compNo] is None:
+                layerNo = len(self.components) - compNo
+                if layerNo in self.staticComponents:
+                    if self.staticComponents[layerNo] is None:
                         # this layer was merged into a following layer
                         continue
                     # static component
                     if frame is None:  # bottom-most layer
-                        frame = self.staticComponents[compNo]
+                        frame = self.staticComponents[layerNo]
                     else:
                         frame = Image.alpha_composite(
-                            frame, self.staticComponents[compNo]
+                            frame, self.staticComponents[layerNo]
                         )
                 else:
                     # animated component

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -31,7 +31,6 @@ class Worker(QtCore.QObject):
     progressBarSetText = pyqtSignal(str)
     encoding = pyqtSignal(bool)
 
-
     def __init__(self, parent, inputFile, outputFile, components):
         QtCore.QObject.__init__(self)
         self.core = parent.core
@@ -135,7 +134,9 @@ class Worker(QtCore.QObject):
         # =~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~==~=~=~=~=~=~=~=~=~=~=~=~=~=~
 
         self.progressBarSetText.emit("Loading audio file...")
-        self.completeAudioArray = self.core.readAudioFile(self.inputFile, self)
+        self.completeAudioArray, duration = self.core.readAudioFile(
+            self.inputFile, self
+        )
 
         self.progressBarUpdate.emit(0)
         self.progressBarSetText.emit("Starting components...")
@@ -144,7 +145,6 @@ class Worker(QtCore.QObject):
             for num, component in enumerate(reversed(self.components))
         ]))
         self.staticComponents = {}
-        numComps = len(self.components)
         for compNo, comp in enumerate(reversed(self.components)):
             comp.preFrameRender(
                 worker=self,
@@ -194,7 +194,7 @@ class Worker(QtCore.QObject):
             self.staticComponents[compNo] = None
 
         ffmpegCommand = self.core.createFfmpegCommand(
-            self.inputFile, self.outputFile
+            self.inputFile, self.outputFile, duration
         )
         print('###### FFMPEG COMMAND ######\n%s' % " ".join(ffmpegCommand))
         print('############################')

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -175,8 +175,8 @@ class Worker(QtCore.QObject):
             self.staticComponents[compNo] = None
 
         ffmpegCommand = self.core.createFfmpegCommand(inputFile, outputFile)
-        print('###### FFMPEG COMMAND ######\n %s' % " ".join(ffmpegCommand))
-        print('###### -------------- ######')
+        print('###### FFMPEG COMMAND ######\n%s' % " ".join(ffmpegCommand))
+        print('############################')
         self.out_pipe = openPipe(
             ffmpegCommand, stdin=sp.PIPE, stdout=sys.stdout, stderr=sys.stdout
         )


### PR DESCRIPTION
Changes:
* A new Sound component to mix in an extra audio file using FFmpeg (no additional options yet)
* Option to use the audio stream in a Video component (audio doesn't loop yet; the stream_loop option does not work on audio for some reason, maybe we can use aloop but I'm not sure how to)
* FFmpeg command shown during export process
* Construction of FFmpeg command moved into `core.py` to allow for future expansion and re-use
* Two new properties for components ('audio' and 'error')
* Components have the ability to cancel the export with a custom message using the 'error' property
* Consecutive components with the 'static' property are merged into a single layer during export
* Ctrl+Alt+Shift+R will redraw the preview window. May be useful as a debugging feature.
* Video thread creation moved into `core.py`, so Core now contains all the basic functions for setting up and creating a video using the component system. `command.py` is really a small script to parse command line arguments and plug them into a Core object