### PR TITLE
Fixes opening behind other windows on OS X

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -57,6 +57,7 @@ def main():
         # window.verticalLayout_2.setContentsMargins(0, topMargin, 0, 0)
 
         main = MainWindow(window, proj)
+        window.raise_()
 
         signal.signal(signal.SIGINT, main.cleanUp)
         atexit.register(main.cleanUp)


### PR DESCRIPTION
Just a quick fix, this will raise the window to the front after it's created.

Shouldn't cause issues on other OSes but please do test to be sure. 👍 