### PR TITLE
new Waveform & Spectrum component + relative coords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ env/*
 *.tar.*
 *.exe
 ffmpeg
+*.bak
+*~

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import os
 
 
-__version__ = '2.0.0.rc2'
+__version__ = '2.0.0.rc3'
 
 
 def package_files(directory):

--- a/src/component.py
+++ b/src/component.py
@@ -304,10 +304,7 @@ class Component(QtCore.QObject, metaclass=ComponentMetaclass):
 
             elif attr in self._relativeWidgets:
                 # Relative widgets: number scales to fit export resolution
-                if self._relativeWidgets[attr] == 'x':
-                    dimension = self.width
-                else:
-                    dimension = self.height
+                dimension = self.width
                 try:
                     oldUserValue = getattr(self, attr)
                 except AttributeError:

--- a/src/component.py
+++ b/src/component.py
@@ -427,7 +427,7 @@ class ComponentError(RuntimeError):
                     name,
                     'an' if any([
                         sys.exc_info()[0].__name__.startswith(vowel)
-                        for vowel in ('A', 'I')
+                        for vowel in ('A', 'I', 'U', 'O', 'E')
                     ]) else 'a',
                     sys.exc_info()[0].__name__,
                     str(sys.exc_info()[1])

--- a/src/component.py
+++ b/src/component.py
@@ -427,7 +427,7 @@ class ComponentError(RuntimeError):
         ComponentError.prevErrors.insert(0, name)
         curTime = time.time()
         if name in ComponentError.prevErrors[1:] \
-                and curTime - ComponentError.lastTime < 0.2:
+                and curTime - ComponentError.lastTime < 1.0:
             # Don't create multiple windows for quickly repeated messages
             return
         ComponentError.lastTime = time.time()

--- a/src/component.py
+++ b/src/component.py
@@ -197,7 +197,7 @@ class Component(QtCore.QObject, metaclass=ComponentMetaclass):
         '''
             Must call super() when subclassing
             Triggered only before a video is exported (video_thread.py)
-                self.worker = the video thread worker
+                self.audioFile = filepath to the main input audio file
                 self.completeAudioArray = a list of audio samples
                 self.sampleSize = number of audio samples per video frame
                 self.progressBarUpdate = signal to set progress bar number
@@ -436,7 +436,7 @@ class ComponentError(RuntimeError):
         import sys
         if sys.exc_info()[0] is not None:
             string = (
-                "%s component's %s encountered %s %s." % (
+                "%s component's %s encountered %s %s: %s" % (
                     caller.__class__.name,
                     name,
                     'an' if any([
@@ -444,12 +444,13 @@ class ComponentError(RuntimeError):
                         for vowel in ('A', 'I')
                     ]) else 'a',
                     sys.exc_info()[0].__name__,
+                    str(sys.exc_info()[1])
                 )
             )
             detail = formatTraceback(sys.exc_info()[2])
         else:
             string = name
-            detail = "Methods:\n%s" % (
+            detail = "Attributes:\n%s" % (
                 "\n".join(
                     [m for m in dir(caller) if not m.startswith('_')]
                 )

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -65,6 +65,11 @@ class Component(Component):
                 'y': 'y',
                 'sizeWidth': 'x',
                 'sizeHeight': 'y',
+                'RG_start': 'x',
+                'LG_start': 'x',
+                'RG_end': 'x',
+                'LG_end': 'x',
+                'RG_centre': 'x',
             },
         )
 

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -37,41 +37,34 @@ class Component(Component):
             self.page.comboBox_fill.addItem(label)
         self.page.comboBox_fill.setCurrentIndex(0)
 
-        self.trackWidgets(
-            {
-                'x': self.page.spinBox_x,
-                'y': self.page.spinBox_y,
-                'sizeWidth': self.page.spinBox_width,
-                'sizeHeight': self.page.spinBox_height,
-                'trans': self.page.checkBox_trans,
-                'spread': self.page.comboBox_spread,
-                'stretch': self.page.checkBox_stretch,
-                'RG_start': self.page.spinBox_radialGradient_start,
-                'LG_start': self.page.spinBox_linearGradient_start,
-                'RG_end': self.page.spinBox_radialGradient_end,
-                'LG_end': self.page.spinBox_linearGradient_end,
-                'RG_centre': self.page.spinBox_radialGradient_spread,
-                'fillType': self.page.comboBox_fill,
-                'color1': self.page.lineEdit_color1,
-                'color2': self.page.lineEdit_color2,
-            }, presetNames={
-                'sizeWidth': 'width',
-                'sizeHeight': 'height',
-            }, colorWidgets={
-                'color1': self.page.pushButton_color1,
-                'color2': self.page.pushButton_color2,
-            }, relativeWidgets={
-                'x': 'x',
-                'y': 'y',
-                'sizeWidth': 'x',
-                'sizeHeight': 'y',
-                'RG_start': 'x',
-                'LG_start': 'x',
-                'RG_end': 'x',
-                'LG_end': 'x',
-                'RG_centre': 'x',
-            },
-        )
+        self.trackWidgets({
+            'x': self.page.spinBox_x,
+            'y': self.page.spinBox_y,
+            'sizeWidth': self.page.spinBox_width,
+            'sizeHeight': self.page.spinBox_height,
+            'trans': self.page.checkBox_trans,
+            'spread': self.page.comboBox_spread,
+            'stretch': self.page.checkBox_stretch,
+            'RG_start': self.page.spinBox_radialGradient_start,
+            'LG_start': self.page.spinBox_linearGradient_start,
+            'RG_end': self.page.spinBox_radialGradient_end,
+            'LG_end': self.page.spinBox_linearGradient_end,
+            'RG_centre': self.page.spinBox_radialGradient_spread,
+            'fillType': self.page.comboBox_fill,
+            'color1': self.page.lineEdit_color1,
+            'color2': self.page.lineEdit_color2,
+        }, presetNames={
+            'sizeWidth': 'width',
+            'sizeHeight': 'height',
+        }, colorWidgets={
+            'color1': self.page.pushButton_color1,
+            'color2': self.page.pushButton_color2,
+        }, relativeWidgets=[
+            'x', 'y',
+            'sizeWidth', 'sizeHeight',
+            'LG_start', 'LG_end',
+            'RG_start', 'RG_end', 'RG_centre',
+        ])
 
     def update(self):
         fillType = self.page.comboBox_fill.currentIndex()

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -60,6 +60,9 @@ class Component(Component):
             }, colorWidgets={
                 'color1': self.page.pushButton_color1,
                 'color2': self.page.pushButton_color2,
+            }, relativeWidgets={
+                'x': 'x',
+                'y': 'y',
             },
         )
 

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -6,7 +6,6 @@ import os
 
 from component import Component
 from toolkit.frame import BlankFrame, FloodFrame, FramePainter, PaintColor
-from toolkit import rgbFromString, pickColor
 
 
 class Component(Component):
@@ -14,25 +13,12 @@ class Component(Component):
     version = '1.0.0'
 
     def widget(self, *args):
-        self.color1 = (0, 0, 0)
-        self.color2 = (133, 133, 133)
         self.x = 0
         self.y = 0
         super().widget(*args)
 
-        self.page.lineEdit_color1.setText('%s,%s,%s' % self.color1)
-        self.page.lineEdit_color2.setText('%s,%s,%s' % self.color2)
-
-        btnStyle1 = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.color1).name()
-
-        btnStyle2 = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.color2).name()
-
-        self.page.pushButton_color1.setStyleSheet(btnStyle1)
-        self.page.pushButton_color2.setStyleSheet(btnStyle2)
-        self.page.pushButton_color1.clicked.connect(lambda: self.pickColor(1))
-        self.page.pushButton_color2.clicked.connect(lambda: self.pickColor(2))
+        self.page.lineEdit_color1.setText('0,0,0')
+        self.page.lineEdit_color2.setText('133,133,133')
 
         # disable color #2 until non-default 'fill' option gets changed
         self.page.lineEdit_color2.setDisabled(True)
@@ -66,16 +52,18 @@ class Component(Component):
                 'LG_end': self.page.spinBox_linearGradient_end,
                 'RG_centre': self.page.spinBox_radialGradient_spread,
                 'fillType': self.page.comboBox_fill,
+                'color1': self.page.lineEdit_color1,
+                'color2': self.page.lineEdit_color2,
             }, presetNames={
                 'sizeWidth': 'width',
                 'sizeHeight': 'height',
-            }
+            }, colorWidgets={
+                'color1': self.page.pushButton_color1,
+                'color2': self.page.pushButton_color2,
+            },
         )
 
     def update(self):
-        self.color1 = rgbFromString(self.page.lineEdit_color1.text())
-        self.color2 = rgbFromString(self.page.lineEdit_color2.text())
-
         fillType = self.page.comboBox_fill.currentIndex()
         if fillType == 0:
             self.page.lineEdit_color2.setEnabled(False)
@@ -160,36 +148,6 @@ class Component(Component):
         )
 
         return image.finalize()
-
-    def loadPreset(self, pr, *args):
-        super().loadPreset(pr, *args)
-
-        self.page.lineEdit_color1.setText('%s,%s,%s' % pr['color1'])
-        self.page.lineEdit_color2.setText('%s,%s,%s' % pr['color2'])
-
-        btnStyle1 = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*pr['color1']).name()
-        btnStyle2 = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*pr['color2']).name()
-        self.page.pushButton_color1.setStyleSheet(btnStyle1)
-        self.page.pushButton_color2.setStyleSheet(btnStyle2)
-
-    def savePreset(self):
-        saveValueStore = super().savePreset()
-        saveValueStore['color1'] = self.color1
-        saveValueStore['color2'] = self.color2
-        return saveValueStore
-
-    def pickColor(self, num):
-        RGBstring, btnStyle = pickColor()
-        if not RGBstring:
-            return
-        if num == 1:
-            self.page.lineEdit_color1.setText(RGBstring)
-            self.page.pushButton_color1.setStyleSheet(btnStyle)
-        else:
-            self.page.lineEdit_color2.setText(RGBstring)
-            self.page.pushButton_color2.setStyleSheet(btnStyle)
 
     def commandHelp(self):
         print('Specify a color:\n    color=255,255,255')

--- a/src/components/color.py
+++ b/src/components/color.py
@@ -63,6 +63,8 @@ class Component(Component):
             }, relativeWidgets={
                 'x': 'x',
                 'y': 'y',
+                'sizeWidth': 'x',
+                'sizeHeight': 'y',
             },
         )
 

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -27,7 +27,7 @@ class Component(Component):
             'xPosition': 'x',
             'yPosition': 'y',
         }, relativeWidgets=[
-            'xPosition', 'yPosition',
+            'xPosition', 'yPosition', 'scale'
         ])
 
     def previewRender(self):

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -21,8 +21,8 @@ class Component(Component):
             'xPosition': self.page.spinBox_x,
             'yPosition': self.page.spinBox_y,
             'stretched': self.page.checkBox_stretch,
-        }, presetNames={
             'mirror': self.page.checkBox_mirror,
+        }, presetNames={
             'imagePath': 'image',
             'xPosition': 'x',
             'yPosition': 'y',

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -13,26 +13,22 @@ class Component(Component):
     def widget(self, *args):
         super().widget(*args)
         self.page.pushButton_image.clicked.connect(self.pickImage)
-        self.trackWidgets(
-            {
-                'imagePath': self.page.lineEdit_image,
-                'scale': self.page.spinBox_scale,
-                'rotate': self.page.spinBox_rotate,
-                'color': self.page.spinBox_color,
-                'xPosition': self.page.spinBox_x,
-                'yPosition': self.page.spinBox_y,
-                'stretched': self.page.checkBox_stretch,
-                'mirror': self.page.checkBox_mirror,
-            },
-            presetNames={
-                'imagePath': 'image',
-                'xPosition': 'x',
-                'yPosition': 'y',
-            }, relativeWidgets={
-                'xPosition': 'x',
-                'yPosition': 'y',
-            },
-        )
+        self.trackWidgets({
+            'imagePath': self.page.lineEdit_image,
+            'scale': self.page.spinBox_scale,
+            'rotate': self.page.spinBox_rotate,
+            'color': self.page.spinBox_color,
+            'xPosition': self.page.spinBox_x,
+            'yPosition': self.page.spinBox_y,
+            'stretched': self.page.checkBox_stretch,
+        }, presetNames={
+            'mirror': self.page.checkBox_mirror,
+            'imagePath': 'image',
+            'xPosition': 'x',
+            'yPosition': 'y',
+        }, relativeWidgets=[
+            'xPosition', 'yPosition',
+        ])
 
     def previewRender(self):
         return self.drawFrame(self.width, self.height)

--- a/src/components/image.py
+++ b/src/components/image.py
@@ -28,6 +28,9 @@ class Component(Component):
                 'imagePath': 'image',
                 'xPosition': 'x',
                 'yPosition': 'y',
+            }, relativeWidgets={
+                'xPosition': 'x',
+                'yPosition': 'y',
             },
         )
 

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -8,7 +8,6 @@ from copy import copy
 
 from component import Component
 from toolkit.frame import BlankFrame
-from toolkit import rgbFromString, pickColor
 
 
 class Component(Component):
@@ -22,7 +21,6 @@ class Component(Component):
         return ['pcm']
 
     def widget(self, *args):
-        self.visColor = (255, 255, 255)
         self.scale = 20
         self.y = 0
         super().widget(*args)
@@ -33,34 +31,16 @@ class Component(Component):
         self.page.comboBox_visLayout.addItem("Top")
         self.page.comboBox_visLayout.setCurrentIndex(0)
 
-        self.page.lineEdit_visColor.setText('%s,%s,%s' % self.visColor)
-        self.page.pushButton_visColor.clicked.connect(lambda: self.pickColor())
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.visColor).name()
-        self.page.pushButton_visColor.setStyleSheet(btnStyle)
+        self.page.lineEdit_visColor.setText('255,255,255')
 
         self.trackWidgets({
+            'visColor': self.page.lineEdit_visColor,
             'layout': self.page.comboBox_visLayout,
             'scale': self.page.spinBox_scale,
             'y': self.page.spinBox_y,
+        }, colorWidgets={
+            'visColor': self.page.pushButton_visColor,
         })
-
-    def update(self):
-        self.visColor = rgbFromString(self.page.lineEdit_visColor.text())
-        super().update()
-
-    def loadPreset(self, pr, *args):
-        super().loadPreset(pr, *args)
-
-        self.page.lineEdit_visColor.setText('%s,%s,%s' % pr['visColor'])
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*pr['visColor']).name()
-        self.page.pushButton_visColor.setStyleSheet(btnStyle)
-
-    def savePreset(self):
-        saveValueStore = super().savePreset()
-        saveValueStore['visColor'] = self.visColor
-        return saveValueStore
 
     def previewRender(self):
         spectrum = numpy.fromfunction(
@@ -98,13 +78,6 @@ class Component(Component):
             self.width, self.height,
             self.spectrumArray[arrayNo],
             self.visColor, self.layout)
-
-    def pickColor(self):
-        RGBstring, btnStyle = pickColor()
-        if not RGBstring:
-            return
-        self.page.lineEdit_visColor.setText(RGBstring)
-        self.page.pushButton_visColor.setStyleSheet(btnStyle)
 
     def transformData(
       self, i, completeAudioArray, sampleSize,

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -40,6 +40,8 @@ class Component(Component):
             'y': self.page.spinBox_y,
         }, colorWidgets={
             'visColor': self.page.pushButton_visColor,
+        }, relativeWidgets={
+            'y': 'y',
         })
 
     def previewRender(self):

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -40,9 +40,9 @@ class Component(Component):
             'y': self.page.spinBox_y,
         }, colorWidgets={
             'visColor': self.page.pushButton_visColor,
-        }, relativeWidgets={
-            'y': 'y',
-        })
+        }, relativeWidgets=[
+            'y',
+        ])
 
     def previewRender(self):
         spectrum = numpy.fromfunction(

--- a/src/components/original.py
+++ b/src/components/original.py
@@ -18,6 +18,9 @@ class Component(Component):
     def names(*args):
         return ['Original Audio Visualization']
 
+    def properties(self):
+        return ['pcm']
+
     def widget(self, *args):
         self.visColor = (255, 255, 255)
         self.scale = 20

--- a/src/components/spectrum.py
+++ b/src/components/spectrum.py
@@ -20,6 +20,7 @@ class Component(Component):
     def widget(self, *args):
         self.previewFrame = None
         super().widget(*args)
+        self._image = BlankFrame(self.width, self.height)
         self.chunkSize = 4 * self.width * self.height
         self.changedOptions = True
 
@@ -268,11 +269,15 @@ class Component(Component):
         return changed
 
     def finalizeFrame(self, imageData):
-        image = Image.frombytes(
-            'RGBA',
-            scale(self.scale, self.width, self.height, int),
-            imageData
-        )
+        try:
+            image = Image.frombytes(
+                'RGBA',
+                scale(self.scale, self.width, self.height, int),
+                imageData
+            )
+            self._image = image
+        except ValueError:
+            image = self._image
         if self.scale != 100 \
                 or self.x != 0 or self.y != 0:
             frame = BlankFrame(self.width, self.height)

--- a/src/components/spectrum.py
+++ b/src/components/spectrum.py
@@ -227,7 +227,8 @@ class Component(Component):
             filter_ = (
                 'aphasemeter=r=%s:s=%sx%s:video=1 [atrash][vtmp1]; '
                 '[atrash] anullsink; '
-                '[vtmp1] colorkey=color=black:similarity=0.1:blend=0.5 ' % (
+                '[vtmp1] colorkey=color=black:similarity=0.1:blend=0.5, '
+                'crop=in_w/8:in_h:(in_w/8)*7:0  '% (
                     self.settings.value("outputFrameRate"),
                     self.settings.value("outputWidth"),
                     self.settings.value("outputHeight"),

--- a/src/components/spectrum.py
+++ b/src/components/spectrum.py
@@ -49,6 +49,9 @@ class Component(Component):
                 'compress': self.page.checkBox_compress,
                 'mono': self.page.checkBox_mono,
                 'hue': self.page.spinBox_hue,
+            }, relativeWidgets={
+                'x': 'x',
+                'y': 'y',
             }
         )
         for widget in self._trackedWidgets.values():

--- a/src/components/spectrum.py
+++ b/src/components/spectrum.py
@@ -30,31 +30,28 @@ class Component(Component):
                 self.update
             )
 
-        self.trackWidgets(
-            {
-                'filterType': self.page.comboBox_filterType,
-                'window': self.page.comboBox_window,
-                'mode': self.page.comboBox_mode,
-                'amplitude': self.page.comboBox_amplitude0,
-                'amplitude1': self.page.comboBox_amplitude1,
-                'amplitude2': self.page.comboBox_amplitude2,
-                'display': self.page.comboBox_display,
-                'zoom': self.page.spinBox_zoom,
-                'tc': self.page.spinBox_tc,
-                'x': self.page.spinBox_x,
-                'y': self.page.spinBox_y,
-                'mirror': self.page.checkBox_mirror,
-                'draw': self.page.checkBox_draw,
-                'scale': self.page.spinBox_scale,
-                'color': self.page.comboBox_color,
-                'compress': self.page.checkBox_compress,
-                'mono': self.page.checkBox_mono,
-                'hue': self.page.spinBox_hue,
-            }, relativeWidgets={
-                'x': 'x',
-                'y': 'y',
-            }
-        )
+        self.trackWidgets({
+            'filterType': self.page.comboBox_filterType,
+            'window': self.page.comboBox_window,
+            'mode': self.page.comboBox_mode,
+            'amplitude': self.page.comboBox_amplitude0,
+            'amplitude1': self.page.comboBox_amplitude1,
+            'amplitude2': self.page.comboBox_amplitude2,
+            'display': self.page.comboBox_display,
+            'zoom': self.page.spinBox_zoom,
+            'tc': self.page.spinBox_tc,
+            'x': self.page.spinBox_x,
+            'y': self.page.spinBox_y,
+            'mirror': self.page.checkBox_mirror,
+            'draw': self.page.checkBox_draw,
+            'scale': self.page.spinBox_scale,
+            'color': self.page.comboBox_color,
+            'compress': self.page.checkBox_compress,
+            'mono': self.page.checkBox_mono,
+            'hue': self.page.spinBox_hue,
+        }, relativeWidgets=[
+            'x', 'y',
+        ])
         for widget in self._trackedWidgets.values():
             connectWidget(widget, lambda: self.changed())
 

--- a/src/components/spectrum.ui
+++ b/src/components/spectrum.ui
@@ -32,6 +32,9 @@
       <number>4</number>
      </property>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_5"/>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_8">
        <item>
         <widget class="QLabel" name="label_4">
@@ -209,6 +212,26 @@
         </spacer>
        </item>
        <item>
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Hue</string>
+         </property>
+         <property name="margin">
+          <number>4</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_hue">
+         <property name="suffix">
+          <string>° </string>
+         </property>
+         <property name="maximum">
+          <number>359</number>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -272,7 +295,7 @@
            <x>0</x>
            <y>0</y>
            <width>561</width>
-           <height>72</height>
+           <height>66</height>
           </rect>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -415,7 +438,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="comboBox_amplitude">
+             <widget class="QComboBox" name="comboBox_amplitude0">
               <item>
                <property name="text">
                 <string>Square root</string>
@@ -554,7 +577,348 @@
          </layout>
         </widget>
        </widget>
-       <widget class="QWidget" name="page_2"/>
+       <widget class="QWidget" name="page_2">
+        <widget class="QWidget" name="verticalLayoutWidget_2">
+         <property name="geometry">
+          <rect>
+           <x>-1</x>
+           <y>-1</y>
+           <width>561</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_6">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Display Scale</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_display">
+              <item>
+               <property name="text">
+                <string>Logarithmic</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Square root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cubic root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Linear</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Reverse Log</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_5">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Amplitude</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_amplitude1">
+              <item>
+               <property name="text">
+                <string>Logarithmic</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Linear</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Minimum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="page_3">
+        <widget class="QWidget" name="verticalLayoutWidget_3">
+         <property name="geometry">
+          <rect>
+           <x>-1</x>
+           <y>-1</y>
+           <width>585</width>
+           <height>64</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="label_9">
+              <property name="text">
+               <string>Mode</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_mode">
+              <item>
+               <property name="text">
+                <string>lissajous</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>lissajous_xy</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>polar</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Amplitude</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_amplitude2">
+              <item>
+               <property name="text">
+                <string>Linear</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Square root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cubic root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Logarithmic</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="label_8">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Zoom</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="spinBox_zoom">
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>10</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkBox_draw">
+              <property name="text">
+               <string>Line</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="page_4">
+        <widget class="QWidget" name="verticalLayoutWidget_4">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>561</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="label_10">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Timeclamp</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="spinBox_tc">
+              <property name="suffix">
+               <string>s</string>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="minimum">
+               <double>0.002000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.017000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="page_5">
+        <widget class="QWidget" name="verticalLayoutWidget_5">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>551</width>
+           <height>31</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11"/>
+          </item>
+         </layout>
+        </widget>
+       </widget>
       </widget>
      </item>
     </layout>

--- a/src/components/spectrum.ui
+++ b/src/components/spectrum.ui
@@ -1,0 +1,582 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>197</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>197</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="comboBox_filterType">
+         <item>
+          <property name="text">
+           <string>Spectrum</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Histogram</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Vector Scope</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Musical Scale</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Phase</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>5</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_xTitleAlign">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>X</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_x">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>-10000</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_yTitleAlign">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Y</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_y">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>-10000</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_10">
+       <item>
+        <widget class="QCheckBox" name="checkBox_compress">
+         <property name="text">
+          <string>Compress</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_mono">
+         <property name="text">
+          <string>Mono</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="checkBox_mirror">
+         <property name="text">
+          <string>Mirror</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scale</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_scale">
+         <property name="buttonSymbols">
+          <enum>QAbstractSpinBox::UpDownArrows</enum>
+         </property>
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>400</number>
+         </property>
+         <property name="value">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QStackedWidget" name="stackedWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="page">
+        <widget class="QWidget" name="verticalLayoutWidget">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>561</width>
+           <height>72</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMaximumSize</enum>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_textColor">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>31</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Window</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_window">
+              <item>
+               <property name="text">
+                <string>hann</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>gauss</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>tukey</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>dolph</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>cauchy</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>parzen</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>poisson</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>rect</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>bartlett</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>hanning</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>hamming</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>blackman</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>welch</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>flattop</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>bharris</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>bnuttall</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>lanczos</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Amplitude</string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_amplitude">
+              <item>
+               <property name="text">
+                <string>Square root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cubic root</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>4thrt</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>5thrt</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Linear</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Logarithmic</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::MinimumExpanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Color </string>
+              </property>
+              <property name="margin">
+               <number>4</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox_color">
+              <item>
+               <property name="text">
+                <string>Channel</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Intensity</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Rainbow</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Moreland</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Nebulae</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Fire</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Fiery</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Fruit</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Cool</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::MinimumExpanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>10</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="page_2"/>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -5,7 +5,6 @@ import os
 
 from component import Component
 from toolkit.frame import FramePainter
-from toolkit import rgbFromString, pickColor
 
 
 class Component(Component):
@@ -33,11 +32,6 @@ class Component(Component):
         self.page.comboBox_textAlign.addItem("Right")
 
         self.page.lineEdit_textColor.setText('%s,%s,%s' % self.textColor)
-        self.page.pushButton_textColor.clicked.connect(self.pickColor)
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.textColor).name()
-        self.page.pushButton_textColor.setStyleSheet(btnStyle)
-
         self.page.lineEdit_title.setText(self.title)
         self.page.comboBox_textAlign.setCurrentIndex(int(self.alignment))
         self.page.spinBox_fontSize.setValue(int(self.fontSize))
@@ -48,21 +42,18 @@ class Component(Component):
             self.update
         )
         self.trackWidgets({
+            'textColor': self.page.lineEdit_textColor,
             'title': self.page.lineEdit_title,
             'alignment': self.page.comboBox_textAlign,
             'fontSize': self.page.spinBox_fontSize,
             'xPosition': self.page.spinBox_xTextAlign,
             'yPosition': self.page.spinBox_yTextAlign,
+        }, colorWidgets={
+            'textColor': self.page.pushButton_textColor,
         })
 
     def update(self):
         self.titleFont = self.page.fontComboBox_titleFont.currentFont()
-        self.textColor = rgbFromString(
-            self.page.lineEdit_textColor.text())
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.textColor).name()
-        self.page.pushButton_textColor.setStyleSheet(btnStyle)
-
         super().update()
 
     def getXY(self):
@@ -86,15 +77,10 @@ class Component(Component):
         font = QFont()
         font.fromString(pr['titleFont'])
         self.page.fontComboBox_titleFont.setCurrentFont(font)
-        self.page.lineEdit_textColor.setText('%s,%s,%s' % pr['textColor'])
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*pr['textColor']).name()
-        self.page.pushButton_textColor.setStyleSheet(btnStyle)
 
     def savePreset(self):
         saveValueStore = super().savePreset()
         saveValueStore['titleFont'] = self.titleFont.toString()
-        saveValueStore['textColor'] = self.textColor
         return saveValueStore
 
     def previewRender(self):
@@ -121,13 +107,6 @@ class Component(Component):
         image.drawText(x, y, self.title)
 
         return image.finalize()
-
-    def pickColor(self):
-        RGBstring, btnStyle = pickColor()
-        if not RGBstring:
-            return
-        self.page.lineEdit_textColor.setText(RGBstring)
-        self.page.pushButton_textColor.setStyleSheet(btnStyle)
 
     def commandHelp(self):
         print('Enter a string to use as centred white text:')

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -53,6 +53,7 @@ class Component(Component):
         }, relativeWidgets={
             'xPosition': 'x',
             'yPosition': 'y',
+            'fontSize': 'y',
         })
 
     def update(self):

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -48,11 +48,9 @@ class Component(Component):
             'yPosition': self.page.spinBox_yTextAlign,
         }, colorWidgets={
             'textColor': self.page.pushButton_textColor,
-        }, relativeWidgets={
-            'xPosition': 'x',
-            'yPosition': 'y',
-            'fontSize': 'y',
-        })
+        }, relativeWidgets=[
+            'xPosition', 'yPosition', 'fontSize',
+        ])
 
     def update(self):
         self.titleFont = self.page.fontComboBox_titleFont.currentFont()

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -17,15 +17,12 @@ class Component(Component):
 
     def widget(self, *args):
         super().widget(*args)
-        height = int(self.settings.value('outputHeight'))
-        width = int(self.settings.value('outputWidth'))
+        # height = int(self.settings.value('outputHeight'))
+        # width = int(self.settings.value('outputWidth'))
         self.textColor = (255, 255, 255)
         self.title = 'Text'
         self.alignment = 1
-        self.fontSize = height / 13.5
-        fm = QtGui.QFontMetrics(self.titleFont)
-        self.xPosition = width / 2 - fm.width(self.title)/2
-        self.yPosition = height / 2 * 1.036
+        self.fontSize = self.height / 13.5
 
         self.page.comboBox_textAlign.addItem("Left")
         self.page.comboBox_textAlign.addItem("Middle")
@@ -35,8 +32,11 @@ class Component(Component):
         self.page.lineEdit_title.setText(self.title)
         self.page.comboBox_textAlign.setCurrentIndex(int(self.alignment))
         self.page.spinBox_fontSize.setValue(int(self.fontSize))
-        self.page.spinBox_xTextAlign.setValue(int(self.xPosition))
-        self.page.spinBox_yTextAlign.setValue(int(self.yPosition))
+
+        fm = QtGui.QFontMetrics(self.titleFont)
+        self.page.spinBox_xTextAlign.setValue(
+            self.width / 2 - fm.width(self.title)/2)
+        self.page.spinBox_yTextAlign.setValue(self.height / 2 * 1.036)
 
         self.page.fontComboBox_titleFont.currentFontChanged.connect(
             self.update
@@ -50,6 +50,9 @@ class Component(Component):
             'yPosition': self.page.spinBox_yTextAlign,
         }, colorWidgets={
             'textColor': self.page.pushButton_textColor,
+        }, relativeWidgets={
+            'xPosition': 'x',
+            'yPosition': 'y',
         })
 
     def update(self):

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -17,8 +17,6 @@ class Component(Component):
 
     def widget(self, *args):
         super().widget(*args)
-        # height = int(self.settings.value('outputHeight'))
-        # width = int(self.settings.value('outputWidth'))
         self.textColor = (255, 255, 255)
         self.title = 'Text'
         self.alignment = 1

--- a/src/components/text.py
+++ b/src/components/text.py
@@ -9,7 +9,7 @@ from toolkit.frame import FramePainter
 
 class Component(Component):
     name = 'Title Text'
-    version = '1.0.0'
+    version = '1.0.1'
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -25,20 +25,17 @@ class Component(Component):
         self.page.comboBox_textAlign.addItem("Left")
         self.page.comboBox_textAlign.addItem("Middle")
         self.page.comboBox_textAlign.addItem("Right")
+        self.page.comboBox_textAlign.setCurrentIndex(int(self.alignment))
 
         self.page.lineEdit_textColor.setText('%s,%s,%s' % self.textColor)
-        self.page.lineEdit_title.setText(self.title)
-        self.page.comboBox_textAlign.setCurrentIndex(int(self.alignment))
         self.page.spinBox_fontSize.setValue(int(self.fontSize))
+        self.page.lineEdit_title.setText(self.title)
 
-        fm = QtGui.QFontMetrics(self.titleFont)
-        self.page.spinBox_xTextAlign.setValue(
-            self.width / 2 - fm.width(self.title)/2)
-        self.page.spinBox_yTextAlign.setValue(self.height / 2 * 1.036)
-
+        self.page.pushButton_center.clicked.connect(self.centerXY)
         self.page.fontComboBox_titleFont.currentFontChanged.connect(
             self.update
         )
+
         self.trackWidgets({
             'textColor': self.page.lineEdit_textColor,
             'title': self.page.lineEdit_title,
@@ -51,10 +48,15 @@ class Component(Component):
         }, relativeWidgets=[
             'xPosition', 'yPosition', 'fontSize',
         ])
+        self.centerXY()
 
     def update(self):
         self.titleFont = self.page.fontComboBox_titleFont.currentFont()
         super().update()
+
+    def centerXY(self):
+        self.setRelativeWidget('xPosition', 0.5)
+        self.setRelativeWidget('yPosition', 0.5)
 
     def getXY(self):
         '''Returns true x, y after considering alignment settings'''

--- a/src/components/text.ui
+++ b/src/components/text.ui
@@ -81,6 +81,9 @@
        </item>
        <item>
         <widget class="QSpinBox" name="spinBox_fontSize">
+         <property name="minimum">
+          <number>1</number>
+         </property>
          <property name="maximum">
           <number>500</number>
          </property>

--- a/src/components/text.ui
+++ b/src/components/text.ui
@@ -20,6 +20,36 @@
       <number>4</number>
      </property>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label_title">
+         <property name="text">
+          <string>Title</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit_title">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Testing New GUI</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_8">
        <item>
         <widget class="QLabel" name="label">
@@ -94,6 +124,55 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_12">
        <item>
+        <widget class="QLabel" name="label_textColor">
+         <property name="text">
+          <string>Text Color</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="lineEdit_textColor"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton_textColor">
+         <property name="maximumSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="MaximumSize" stdset="0">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <item>
         <widget class="QLabel" name="label_textLayout">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -126,64 +205,9 @@
         </spacer>
        </item>
        <item>
-        <widget class="QLabel" name="label_textColor">
+        <widget class="QPushButton" name="pushButton_center">
          <property name="text">
-          <string>Text Color</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_textColor">
-         <property name="maximumSize">
-          <size>
-           <width>32</width>
-           <height>32</height>
-          </size>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="MaximumSize" stdset="0">
-          <size>
-           <width>32</width>
-           <height>32</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="lineEdit_textColor"/>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_title">
-         <property name="text">
-          <string>Title</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="lineEdit_title">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Testing New GUI</string>
+          <string>Center</string>
          </property>
         </widget>
        </item>

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -4,10 +4,10 @@ import os
 import math
 import subprocess
 
-from component import Component, ComponentError
-from toolkit.frame import BlankFrame
-from toolkit.ffmpeg import testAudioStream, FfmpegVideo
-from toolkit import openPipe, closePipe, checkOutput, scale
+from component import Component
+from toolkit.frame import BlankFrame, scale
+from toolkit.ffmpeg import openPipe, closePipe, testAudioStream, FfmpegVideo
+from toolkit import checkOutput
 
 
 class Component(Component):
@@ -132,7 +132,7 @@ class Component(Component):
         ]
         command.extend(self.makeFfmpegFilter())
         command.extend([
-            '-vcodec', 'rawvideo', '-',
+            '-codec:v', 'rawvideo', '-',
             '-ss', '90',
             '-frames:v', '1',
         ])

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -23,26 +23,23 @@ class Component(Component):
         super().widget(*args)
         self._image = BlankFrame(self.width, self.height)
         self.page.pushButton_video.clicked.connect(self.pickVideo)
-        self.trackWidgets(
-            {
-                'videoPath': self.page.lineEdit_video,
-                'loopVideo': self.page.checkBox_loop,
-                'useAudio': self.page.checkBox_useAudio,
-                'distort': self.page.checkBox_distort,
-                'scale': self.page.spinBox_scale,
-                'volume': self.page.spinBox_volume,
-                'xPosition': self.page.spinBox_x,
-                'yPosition': self.page.spinBox_y,
-            }, presetNames={
-                'videoPath': 'video',
-                'loopVideo': 'loop',
-                'xPosition': 'x',
-                'yPosition': 'y',
-            }, relativeWidgets={
-                'xPosition': 'x',
-                'yPosition': 'y',
-            }
-        )
+        self.trackWidgets({
+            'videoPath': self.page.lineEdit_video,
+            'loopVideo': self.page.checkBox_loop,
+            'useAudio': self.page.checkBox_useAudio,
+            'distort': self.page.checkBox_distort,
+            'scale': self.page.spinBox_scale,
+            'volume': self.page.spinBox_volume,
+            'xPosition': self.page.spinBox_x,
+            'yPosition': self.page.spinBox_y,
+        }, presetNames={
+            'videoPath': 'video',
+            'loopVideo': 'loop',
+            'xPosition': 'x',
+            'yPosition': 'y',
+        }, relativeWidgets=[
+            'xPosition', 'yPosition',
+        ])
 
     def update(self):
         if self.page.checkBox_useAudio.isChecked():

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -16,12 +16,12 @@ class Component(Component):
 
     def widget(self, *args):
         self.videoPath = ''
-        self.badVideo = False
         self.badAudio = False
         self.x = 0
         self.y = 0
         self.loopVideo = False
         super().widget(*args)
+        self._image = BlankFrame(self.width, self.height)
         self.page.pushButton_video.clicked.connect(self.pickVideo)
         self.trackWidgets(
             {
@@ -70,8 +70,6 @@ class Component(Component):
 
         if not self.videoPath:
             self.lockError("There is no video selected.")
-        elif self.badVideo:
-            self.lockError("Could not identify an audio stream in this video.")
         elif not os.path.exists(self.videoPath):
             self.lockError("The video selected does not exist!")
         elif os.path.realpath(self.videoPath) == os.path.realpath(outputFile):
@@ -199,14 +197,10 @@ class Component(Component):
                     'RGBA',
                     scale(self.scale, self.width, self.height, int),
                     imageData)
-
+            self._image = image
         except ValueError:
-            print(
-                '### BAD VIDEO SELECTED ###\n'
-                'Video will not export with these settings'
-            )
-            self.badVideo = True
-            return BlankFrame(self.width, self.height)
+            # use last good frame
+            image = self._image
 
         if self.scale != 100 \
                 or self.xPosition != 0 or self.yPosition != 0:
@@ -214,5 +208,4 @@ class Component(Component):
             frame.paste(image, box=(self.xPosition, self.yPosition))
         else:
             frame = image
-        self.badVideo = False
         return frame

--- a/src/components/video.py
+++ b/src/components/video.py
@@ -38,6 +38,9 @@ class Component(Component):
                 'loopVideo': 'loop',
                 'xPosition': 'x',
                 'yPosition': 'y',
+            }, relativeWidgets={
+                'xPosition': 'x',
+                'yPosition': 'y',
             }
         )
 

--- a/src/components/waveform.py
+++ b/src/components/waveform.py
@@ -28,25 +28,22 @@ class Component(Component):
                 self.update
             )
 
-        self.trackWidgets(
-            {
-                'color': self.page.lineEdit_color,
-                'mode': self.page.comboBox_mode,
-                'amplitude': self.page.comboBox_amplitude,
-                'x': self.page.spinBox_x,
-                'y': self.page.spinBox_y,
-                'mirror': self.page.checkBox_mirror,
-                'scale': self.page.spinBox_scale,
-                'opacity': self.page.spinBox_opacity,
-                'compress': self.page.checkBox_compress,
-                'mono': self.page.checkBox_mono,
-            }, colorWidgets={
-                'color': self.page.pushButton_color,
-            }, relativeWidgets={
-                'x': 'x',
-                'y': 'y',
-            }
-        )
+        self.trackWidgets({
+            'color': self.page.lineEdit_color,
+            'mode': self.page.comboBox_mode,
+            'amplitude': self.page.comboBox_amplitude,
+            'x': self.page.spinBox_x,
+            'y': self.page.spinBox_y,
+            'mirror': self.page.checkBox_mirror,
+            'scale': self.page.spinBox_scale,
+            'opacity': self.page.spinBox_opacity,
+            'compress': self.page.checkBox_compress,
+            'mono': self.page.checkBox_mono,
+        }, colorWidgets={
+            'color': self.page.pushButton_color,
+        }, relativeWidgets=[
+            'x', 'y',
+        ])
 
     def previewRender(self):
         self.updateChunksize()

--- a/src/components/waveform.py
+++ b/src/components/waveform.py
@@ -41,6 +41,9 @@ class Component(Component):
                 'mono': self.page.checkBox_mono,
             }, colorWidgets={
                 'color': self.page.pushButton_color,
+            }, relativeWidgets={
+                'x': 'x',
+                'y': 'y',
             }
         )
 

--- a/src/components/waveform.py
+++ b/src/components/waveform.py
@@ -1,0 +1,139 @@
+from PIL import Image
+from PyQt5 import QtGui, QtCore, QtWidgets
+from PyQt5.QtGui import QColor
+import os
+import math
+import subprocess
+
+from component import Component, ComponentError
+from toolkit.frame import BlankFrame
+from toolkit import openPipe, checkOutput, rgbFromString
+from toolkit.ffmpeg import FfmpegVideo
+
+
+class Component(Component):
+    name = 'Waveform'
+    version = '1.0.0'
+
+    def widget(self, *args):
+        self.color = (255, 255, 255)
+        super().widget(*args)
+
+        self.page.lineEdit_color.setText('%s,%s,%s' % self.color)
+        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
+            % QColor(*self.color1).name()
+        self.page.lineEdit_color.setStylesheet(btnStyle)
+        self.page.pushButton_color.clicked.connect(lambda: self.pickColor())
+
+        self.trackWidgets(
+            {
+                'mode': self.page.comboBox_mode,
+                'x': self.page.spinBox_x,
+                'y': self.page.spinBox_y,
+                'mirror': self.page.checkBox_mirror,
+                'scale': self.page.spinBox_scale,
+            }
+        )
+
+    def update(self):
+        self.color = rgbFromString(self.page.lineEdit_color.text())
+        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
+            % QColor(*self.color).name()
+        self.page.pushButton_color.setStyleSheet(btnStyle)
+        super().update()
+
+    def previewRender(self):
+        self.updateChunksize()
+        frame = self.getPreviewFrame(self.width, self.height)
+        if not frame:
+            return BlankFrame(self.width, self.height)
+        else:
+            return frame
+
+    def preFrameRender(self, **kwargs):
+        super().preFrameRender(**kwargs)
+        self.updateChunksize()
+        self.video = FfmpegVideo(
+            inputPath=self.audioFile,
+            filter_=makeFfmpegFilter(),
+            width=self.width, height=self.height,
+            chunkSize=self.chunkSize,
+            frameRate=int(self.settings.value("outputFrameRate")),
+            parent=self.parent, component=self,
+        )
+
+    def frameRender(self, frameNo):
+        if FfmpegVideo.threadError is not None:
+            raise FfmpegVideo.threadError
+        return finalizeFrame(self.video.frame(frameNo))
+
+    def postFrameRender(self):
+        closePipe(self.video.pipe)
+
+    def getPreviewFrame(self, width, height):
+        inputFile = self.parent.window.lineEdit_audioFile.text()
+        if not inputFile or not os.path.exists(inputFile):
+            return
+
+        command = [
+            self.core.FFMPEG_BIN,
+            '-thread_queue_size', '512',
+            '-i', inputFile,
+            '-f', 'image2pipe',
+            '-pix_fmt', 'rgba',
+        ]
+        command.extend(self.makeFfmpegFilter())
+        command.extend([
+            '-vcodec', 'rawvideo', '-',
+            '-ss', '90',
+            '-frames:v', '1',
+        ])
+        pipe = openPipe(
+            command, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, bufsize=10**8
+        )
+        byteFrame = pipe.stdout.read(self.chunkSize)
+        closePipe(pipe)
+
+        frame = finalizeFrame(self, byteFrame, width, height)
+        return frame
+
+    def makeFfmpegFilter(self):
+        w, h = scale(self.scale, self.width, self.height, str)
+        return [
+            '-filter_complex',
+            '[0:a] showwaves=s=%sx%s:mode=%s,format=rgba [v]' % (
+                w, h, self.mode,
+            ),
+            '-map', '[v]',
+            '-map', '0:a',
+        ]
+
+    def updateChunksize(self):
+        if self.scale != 100:
+            width, height = scale(self.scale, self.width, self.height, int)
+        else:
+            width, height = self.width, self.height
+        self.chunkSize = 4 * width * height
+
+
+def scale(scale, width, height, returntype=None):
+    width = (float(width) / 100.0) * float(scale)
+    height = (float(height) / 100.0) * float(scale)
+    if returntype == str:
+        return (str(math.ceil(width)), str(math.ceil(height)))
+    elif returntype == int:
+        return (math.ceil(width), math.ceil(height))
+    else:
+        return (width, height)
+
+
+def finalizeFrame(self, imageData, width, height):
+    # frombytes goes here
+    if self.scale != 100 \
+            or self.x != 0 or self.y != 0:
+        frame = BlankFrame(width, height)
+        frame.paste(image, box=(self.x, self.y))
+    else:
+        frame = image
+    return frame

--- a/src/components/waveform.py
+++ b/src/components/waveform.py
@@ -7,7 +7,7 @@ import subprocess
 
 from component import Component
 from toolkit.frame import BlankFrame, scale
-from toolkit import checkOutput, rgbFromString, pickColor
+from toolkit import checkOutput
 from toolkit.ffmpeg import (
     openPipe, closePipe, getAudioDuration, FfmpegVideo, exampleSound
 )
@@ -18,15 +18,9 @@ class Component(Component):
     version = '1.0.0'
 
     def widget(self, *args):
-        self.color = (255, 255, 255)
         super().widget(*args)
 
-        self.page.lineEdit_color.setText('%s,%s,%s' % self.color)
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.color).name()
-        self.page.pushButton_color.setStyleSheet(btnStyle)
-        self.page.pushButton_color.clicked.connect(lambda: self.pickColor())
-        self.page.spinBox_scale.valueChanged.connect(self.updateChunksize)
+        self.page.lineEdit_color.setText('255,255,255')
 
         if hasattr(self.parent, 'window'):
             self.parent.window.lineEdit_audioFile.textChanged.connect(
@@ -35,6 +29,7 @@ class Component(Component):
 
         self.trackWidgets(
             {
+                'color': self.page.lineEdit_color,
                 'mode': self.page.comboBox_mode,
                 'amplitude': self.page.comboBox_amplitude,
                 'x': self.page.spinBox_x,
@@ -44,35 +39,10 @@ class Component(Component):
                 'opacity': self.page.spinBox_opacity,
                 'compress': self.page.checkBox_compress,
                 'mono': self.page.checkBox_mono,
+            }, colorWidgets={
+                'color': self.page.pushButton_color,
             }
         )
-
-    def update(self):
-        self.color = rgbFromString(self.page.lineEdit_color.text())
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*self.color).name()
-        self.page.pushButton_color.setStyleSheet(btnStyle)
-        super().update()
-
-    def loadPreset(self, pr, *args):
-        super().loadPreset(pr, *args)
-
-        self.page.lineEdit_color.setText('%s,%s,%s' % pr['color'])
-        btnStyle = "QPushButton { background-color : %s; outline: none; }" \
-            % QColor(*pr['color']).name()
-        self.page.pushButton_color.setStyleSheet(btnStyle)
-
-    def savePreset(self):
-        saveValueStore = super().savePreset()
-        saveValueStore['color'] = self.color
-        return saveValueStore
-
-    def pickColor(self):
-        RGBstring, btnStyle = pickColor()
-        if not RGBstring:
-            return
-        self.page.lineEdit_color.setText(RGBstring)
-        self.page.pushButton_color.setStyleSheet(btnStyle)
 
     def previewRender(self):
         self.updateChunksize()

--- a/src/components/waveform.py
+++ b/src/components/waveform.py
@@ -19,6 +19,7 @@ class Component(Component):
 
     def widget(self, *args):
         super().widget(*args)
+        self._image = BlankFrame(self.width, self.height)
 
         self.page.lineEdit_color.setText('255,255,255')
 
@@ -178,11 +179,15 @@ class Component(Component):
         self.chunkSize = 4 * width * height
 
     def finalizeFrame(self, imageData):
-        image = Image.frombytes(
-            'RGBA',
-            scale(self.scale, self.width, self.height, int),
-            imageData
-        )
+        try:
+            image = Image.frombytes(
+                'RGBA',
+                scale(self.scale, self.width, self.height, int),
+                imageData
+            )
+            self._image = image
+        except ValueError:
+            image = self._image
         if self.scale != 100 \
                 or self.x != 0 or self.y != 0:
             frame = BlankFrame(self.width, self.height)

--- a/src/components/waveform.ui
+++ b/src/components/waveform.ui
@@ -66,12 +66,17 @@
          </item>
          <item>
           <property name="text">
-           <string>P2p</string>
+           <string>Point</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Point</string>
+           <string>Frequency Bar</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Frequency Line</string>
           </property>
          </item>
         </widget>
@@ -180,12 +185,16 @@
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Wave Color</string>
+        <string>Color</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="lineEdit_color"/>
+      <widget class="QLineEdit" name="lineEdit_color">
+       <property name="inputMethodHints">
+        <set>Qt::ImhNone</set>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="pushButton_color">
@@ -244,10 +253,10 @@
         <string>%</string>
        </property>
        <property name="minimum">
-        <number>10</number>
+        <number>0</number>
        </property>
        <property name="maximum">
-        <number>400</number>
+        <number>100</number>
        </property>
        <property name="value">
         <number>100</number>

--- a/src/components/waveform.ui
+++ b/src/components/waveform.ui
@@ -226,9 +226,31 @@
       </spacer>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox_mirror">
+      <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Mirror</string>
+        <string>Opacity</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBox_opacity">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::UpDownArrows</enum>
+       </property>
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>400</number>
+       </property>
+       <property name="value">
+        <number>100</number>
        </property>
       </widget>
      </item>
@@ -259,6 +281,75 @@
        <property name="value">
         <number>100</number>
        </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_10">
+     <item>
+      <widget class="QCheckBox" name="checkBox_compress">
+       <property name="text">
+        <string>Compress</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_mono">
+       <property name="text">
+        <string>Mono</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_mirror">
+       <property name="text">
+        <string>Mirror</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Amplitude</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBox_amplitude">
+       <item>
+        <property name="text">
+         <string>Linear</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Logarithmic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Square root</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Cubic root</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>

--- a/src/components/waveform.ui
+++ b/src/components/waveform.ui
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>197</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>197</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <item>
+        <widget class="QLabel" name="label_textColor">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>31</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Mode</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="comboBox_mode">
+         <item>
+          <property name="text">
+           <string>Cline</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Line</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>P2p</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Point</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>5</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_xTitleAlign">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>X</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_x">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>-10000</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_yTitleAlign">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Y</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBox_y">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>80</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="minimum">
+          <number>-10000</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_9">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Wave Color</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineEdit_color"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_color">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox_mirror">
+       <property name="text">
+        <string>Mirror</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Scale</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="spinBox_scale">
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::UpDownArrows</enum>
+       </property>
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>400</number>
+       </property>
+       <property name="value">
+        <number>100</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/core.py
+++ b/src/core.py
@@ -506,6 +506,7 @@ class Core:
             "outputContainer": "MP4",
             "projectDir": os.path.join(cls.dataDir, 'projects'),
             "pref_insertCompAtTop": True,
+            "pref_genericPreview": True,
         }
 
         for parm, value in defaultSettings.items():

--- a/src/core.py
+++ b/src/core.py
@@ -451,8 +451,8 @@ class Core:
                 '1280x720',
                 '854x480',
             ],
-            'windowHasFocus': False,
             'FFMPEG_BIN': findFfmpeg(),
+            'windowHasFocus': False,
             'canceled': False,
         }
 
@@ -492,7 +492,7 @@ class Core:
 
     @classmethod
     def loadDefaultSettings(cls):
-        defaultSettings = {
+        cls.defaultSettings = {
             "outputWidth": 1280,
             "outputHeight": 720,
             "outputFrameRate": 30,
@@ -509,7 +509,7 @@ class Core:
             "pref_genericPreview": True,
         }
 
-        for parm, value in defaultSettings.items():
+        for parm, value in cls.defaultSettings.items():
             if cls.settings.value(parm) is None:
                 cls.settings.setValue(parm, value)
 

--- a/src/core.py
+++ b/src/core.py
@@ -161,7 +161,7 @@ class Core:
                     for widget, value in data['WindowFields']:
                         widget = eval('loader.window.%s' % widget)
                         widget.blockSignals(True)
-                        widget.setText(value)
+                        toolkit.setWidgetValue(widget, value)
                         widget.blockSignals(False)
 
                 for key, value in data['Settings']:

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -581,7 +581,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.showMessage(
             msg=msg,
             detail=detail,
-            icon='Warning',
+            icon='Critical',
         )
 
     def changeEncodingStatus(self, status):

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -644,9 +644,12 @@ class MainWindow(QtWidgets.QMainWindow):
     def updateResolution(self):
         resIndex = int(self.window.comboBox_resolution.currentIndex())
         res = Core.resolutions[resIndex].split('x')
+        changed = res[0] != self.settings.value("outputWidth")
         self.settings.setValue('outputWidth', res[0])
         self.settings.setValue('outputHeight', res[1])
-        self.drawPreview()
+        if changed:
+            for i in range(len(self.core.selectedComponents)):
+                self.core.updateComponent(i)
 
     def drawPreview(self, force=False, **kwargs):
         '''Use autosave keyword arg to force saving or not saving if needed'''

--- a/src/mainwindow.py
+++ b/src/mainwindow.py
@@ -791,6 +791,8 @@ class MainWindow(QtWidgets.QMainWindow):
             field.blockSignals(True)
             field.setText('')
             field.blockSignals(False)
+        self.progressBarUpdated(0)
+        self.progressBarSetText('')
 
     @disableWhenEncoding
     def createNewProject(self, prompt=True):

--- a/src/preview_thread.py
+++ b/src/preview_thread.py
@@ -59,7 +59,9 @@ class Worker(QtCore.QObject):
             components = nextPreviewInformation["components"]
             for component in reversed(components):
                 try:
+                    component.lockSize(width, height)
                     newFrame = component.previewRender()
+                    component.unlockSize()
                     frame = Image.alpha_composite(
                         frame, newFrame
                     )

--- a/src/toolkit/common.py
+++ b/src/toolkit/common.py
@@ -6,20 +6,7 @@ import string
 import os
 import sys
 import subprocess
-import signal
-import math
 from collections import OrderedDict
-
-
-def scale(scale, width, height, returntype=None):
-    width = (float(width) / 100.0) * float(scale)
-    height = (float(height) / 100.0) * float(scale)
-    if returntype == str:
-        return (str(math.ceil(width)), str(math.ceil(height)))
-    elif returntype == int:
-        return (math.ceil(width), math.ceil(height))
-    else:
-        return (width, height)
 
 
 def badName(name):
@@ -68,14 +55,6 @@ def pipeWrapper(func):
 def checkOutput(commandList, **kwargs):
     return subprocess.check_output(commandList, **kwargs)
 
-
-@pipeWrapper
-def openPipe(commandList, **kwargs):
-    return subprocess.Popen(commandList, **kwargs)
-
-def closePipe(pipe):
-    pipe.stdout.close()
-    pipe.send_signal(signal.SIGINT)
 
 def disableWhenEncoding(func):
     def decorator(self, *args, **kwargs):

--- a/src/toolkit/common.py
+++ b/src/toolkit/common.py
@@ -74,25 +74,6 @@ def disableWhenOpeningProject(func):
     return decorator
 
 
-def pickColor():
-    '''
-        Use color picker to get color input from the user,
-        and return this as an RGB string and QPushButton stylesheet.
-        In a subclass apply stylesheet to any color selection widgets
-    '''
-    dialog = QtWidgets.QColorDialog()
-    dialog.setOption(QtWidgets.QColorDialog.ShowAlphaChannel, True)
-    color = dialog.getColor()
-    if color.isValid():
-        RGBstring = '%s,%s,%s' % (
-            str(color.red()), str(color.green()), str(color.blue()))
-        btnStyle = "QPushButton{background-color: %s; outline: none;}" \
-            % color.name()
-        return RGBstring, btnStyle
-    else:
-        return None, None
-
-
 def rgbFromString(string):
     '''Turns an RGB string like "255, 255, 255" into a tuple'''
     try:

--- a/src/toolkit/common.py
+++ b/src/toolkit/common.py
@@ -113,3 +113,46 @@ def formatTraceback(tb=None):
         import sys
         tb = sys.exc_info()[2]
     return 'Traceback:\n%s' % "\n".join(traceback.format_tb(tb))
+
+
+def connectWidget(widget, func):
+    if type(widget) == QtWidgets.QLineEdit:
+        widget.textChanged.connect(func)
+    elif type(widget) == QtWidgets.QSpinBox \
+            or type(widget) == QtWidgets.QDoubleSpinBox:
+        widget.valueChanged.connect(func)
+    elif type(widget) == QtWidgets.QCheckBox:
+        widget.stateChanged.connect(func)
+    elif type(widget) == QtWidgets.QComboBox:
+        widget.currentIndexChanged.connect(func)
+    else:
+        return False
+    return True
+
+
+def setWidgetValue(widget, val):
+    '''Generic setValue method for use with any typical QtWidget'''
+    if type(widget) == QtWidgets.QLineEdit:
+        widget.setText(val)
+    elif type(widget) == QtWidgets.QSpinBox \
+            or type(widget) == QtWidgets.QDoubleSpinBox:
+        widget.setValue(val)
+    elif type(widget) == QtWidgets.QCheckBox:
+        widget.setChecked(val)
+    elif type(widget) == QtWidgets.QComboBox:
+        widget.setCurrentIndex(val)
+    else:
+        return False
+    return True
+
+
+def getWidgetValue(widget):
+    if type(widget) == QtWidgets.QLineEdit:
+        return widget.text()
+    elif type(widget) == QtWidgets.QSpinBox \
+            or type(widget) == QtWidgets.QDoubleSpinBox:
+        return widget.value()
+    elif type(widget) == QtWidgets.QCheckBox:
+        return widget.isChecked()
+    elif type(widget) == QtWidgets.QComboBox:
+        return widget.currentIndex()

--- a/src/toolkit/ffmpeg.py
+++ b/src/toolkit/ffmpeg.py
@@ -37,6 +37,7 @@ class FfmpegVideo:
         self.frameNo = -1
         self.currentFrame = 'None'
         self.map_ = None
+        self.debug = False
 
         if 'loopVideo' in kwargs and kwargs['loopVideo']:
             self.loopValue = '-1'
@@ -47,6 +48,8 @@ class FfmpegVideo:
                 kwargs['filter_'].insert(0, '-filter_complex')
         else:
             kwargs['filter_'] = None
+        if 'debug' in kwargs:
+            self.debug = True
 
         self.command = [
             core.Core.FFMPEG_BIN,
@@ -62,7 +65,6 @@ class FfmpegVideo:
                 kwargs['filter_']
             )
         self.command.extend([
-            '-s:v', '%sx%s' % (self.width, self.height),
             '-codec:v', 'rawvideo', '-',
         ])
 
@@ -88,11 +90,15 @@ class FfmpegVideo:
             self.frameBuffer.task_done()
 
     def fillBuffer(self):
-        import sys
-        print(self.command)
+        if self.debug:
+            print(" ".join([word for word in self.command]))
+            err = sys.__stdout__
+        else:
+            err = subprocess.DEVNULL
+
         self.pipe = openPipe(
             self.command, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-            stderr=sys.__stdout__, bufsize=10**8
+            stderr=err, bufsize=10**8
         )
         while True:
             if self.parent.canceled:

--- a/src/toolkit/frame.py
+++ b/src/toolkit/frame.py
@@ -6,6 +6,7 @@ from PIL import Image
 from PIL.ImageQt import ImageQt
 import sys
 import os
+import math
 
 import core
 
@@ -39,6 +40,17 @@ class PaintColor(QtGui.QColor):
             super().__init__(r, g, b, a)
         else:
             super().__init__(b, g, r, a)
+
+
+def scale(scale, width, height, returntype=None):
+    width = (float(width) / 100.0) * float(scale)
+    height = (float(height) / 100.0) * float(scale)
+    if returntype == str:
+        return (str(math.ceil(width)), str(math.ceil(height)))
+    elif returntype == int:
+        return (math.ceil(width), math.ceil(height))
+    else:
+        return (width, height)
 
 
 def defaultSize(framefunc):

--- a/src/toolkit/frame.py
+++ b/src/toolkit/frame.py
@@ -42,9 +42,9 @@ class PaintColor(QtGui.QColor):
             super().__init__(b, g, r, a)
 
 
-def scale(scale, width, height, returntype=None):
-    width = (float(width) / 100.0) * float(scale)
-    height = (float(height) / 100.0) * float(scale)
+def scale(scalePercent, width, height, returntype=None):
+    width = (float(width) / 100.0) * float(scalePercent)
+    height = (float(height) / 100.0) * float(scalePercent)
     if returntype == str:
         return (str(math.ceil(width)), str(math.ceil(height)))
     elif returntype == int:

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -153,7 +153,7 @@ class Worker(QtCore.QObject):
         for compNo, comp in enumerate(reversed(self.components)):
             try:
                 comp.preFrameRender(
-                    worker=self,
+                    audioFile=self.inputFile,
                     completeAudioArray=self.completeAudioArray,
                     sampleSize=self.sampleSize,
                     progressBarUpdate=self.progressBarUpdate,


### PR DESCRIPTION
* New "Waveform" component with modes for using the FFmpeg filters showwaves and showfreqs
* New "Spectrum" component with modes for aphasemeter, showcqt, ahistogram, showspectrum, avectorscope
* Components can define "relative widgets" which will have their value stored normally (pixel value as an integer), but this value is also stored separately as a float which is used to update the pixel value in the widget when the output resolution changes. Thus a title text in the centre of the screen will remain in the centre of the screen. **Unfortunately this breaks presets and projects saved in old versions.**
* Text component has a 'center' button to set the x, y to 0.5, 0.5
* Components can define "color widgets" which will have their value stored as an rgbTuple instead of a string, update the associated pushButton stylesheet, and automatically create a pickColor method. So adding a new colour option to a component is now just as easy as adding a new checkbox.