### PR TITLE
Fix #70 - Crash when exporting video in GUI mode

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -58,11 +58,15 @@ class Command(QtCore.QObject):
         )
         self.parser.add_argument(
             '--test', action='store_true',
-            help='run tests, generate logfiles, then exit'
+            help='run tests and create a report full of debugging info'
         )
         self.parser.add_argument(
             '--debug', action='store_true',
             help='create bigger logfiles while program is running'
+        )
+        self.parser.add_argument(
+            '--no-preview', action='store_true',
+            help='disable live preview during export in GUI mode'
         )
 
         # optional arguments
@@ -139,6 +143,9 @@ class Command(QtCore.QObject):
         elif self.args.input and self.args.output:
             self.createAudioVisualisation(self.args.input, self.args.output)
             return "commandline"
+
+        elif self.args.no_preview:
+            core.Core.previewEnabled = False
 
         elif 'help' not in sys.argv and self.args.projpath is None and '--debug' not in sys.argv:
             self.parser.print_help()

--- a/src/core.py
+++ b/src/core.py
@@ -487,6 +487,7 @@ class Core:
             ],
             'logDir': os.path.join(dataDir, 'log'),
             'logEnabled': False,
+            'previewEnabled': True,
         }
 
         settings['videoFormats'] = toolkit.appendUppercase([

--- a/src/gui/mainwindow.py
+++ b/src/gui/mainwindow.py
@@ -4,7 +4,7 @@
     This shows a preview of the video being created and allows for saving
     projects and exporting the video at a later time.
 '''
-from PyQt5 import QtCore, QtGui, QtWidgets, uic
+from PyQt5 import QtCore, QtWidgets, uic
 import PyQt5.QtWidgets as QtWidgets
 from PIL import Image
 from queue import Queue
@@ -754,7 +754,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.autosave()
         self.updateWindowTitle()
 
-    @QtCore.pyqtSlot(QtGui.QImage)
+    @QtCore.pyqtSlot('QImage')
     def showPreviewImage(self, image):
         self.previewWindow.changePixmap(image)
 

--- a/src/gui/preview_thread.py
+++ b/src/gui/preview_thread.py
@@ -80,6 +80,8 @@ class Worker(QtCore.QObject):
                 except RuntimeError as e:
                     log.error(str(e))
             else:
+                # We must store a reference to this QImage
+                # or else Qt will garbage-collect it on the C++ side
                 self.frame = ImageQt(frame)
                 self.imageCreated.emit(QtGui.QImage(self.frame))
 

--- a/src/gui/preview_thread.py
+++ b/src/gui/preview_thread.py
@@ -38,6 +38,7 @@ class Worker(QtCore.QObject):
           "components": components,
         }
         self.queue.put(dic)
+        log.debug('Preview thread id: {}'.format(int(QtCore.QThread.currentThreadId())))
 
     @pyqtSlot()
     def process(self):

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -322,7 +322,7 @@ class Worker(QtCore.QObject):
                         break
                     # else fetch the next frame & add to the buffer
                     audioI_, frame = self.renderQueue.get()
-                    frameBuffer[audioI_] = frame.copy()
+                    frameBuffer[audioI_] = frame
                     self.renderQueue.task_done()
                 if self.canceled:
                     break

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -120,11 +120,9 @@ class Worker(QtCore.QObject):
             adds it to the checkerboard and emits a final QImage
             to the MainWindow for the live preview
         '''
-        background = Checkerboard(self.width, self.height)
-        image = Image.alpha_composite(background.copy(), frame)
         # We must store a reference to this QImage
         # or else Qt will garbage-collect it on the C++ side
-        self.latestPreview = ImageQt(image)
+        self.latestPreview = ImageQt(frame)
         self.imageCreated.emit(QtGui.QImage(self.latestPreview))
         self.lastPreview = time.time()
 

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -133,6 +133,8 @@ class Worker(QtCore.QObject):
     @pyqtSlot()
     def createVideo(self):
         log.debug("Video worker received signal to createVideo")
+        log.debug(
+            'Video thread id: {}'.format(int(QtCore.QThread.currentThreadId())))
         numpy.seterr(divide='ignore')
         self.encoding.emit(True)
         self.extraAudio = []

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -44,6 +44,7 @@ class Worker(QtCore.QObject):
         self.settings = parent.settings
         self.modules = parent.core.modules
         parent.createVideo.connect(self.createVideo)
+        self.previewEnabled = type(parent.core).previewEnabled
 
         #self.parent = parent
         self.components = components
@@ -327,7 +328,7 @@ class Worker(QtCore.QObject):
                     break
 
                 # Update live preview
-                if time.time() - self.lastPreview > 0.5:
+                if self.previewEnabled and time.time() - self.lastPreview > 0.5:
                     self.showPreview(frameBuffer[audioI])
 
                 try:


### PR DESCRIPTION
I was finally able to fix the memory error which made the program crash during export.

Funnily enough, it was caused by the same problem I had encountered somewhere else in the code. If a QImage goes through a Qt Signal/Slot, you need to store a reference to it within Python-land or else PyQt thinks it can trigger garbage collection on the C++ side, which then causes a memory error the next time Python tries to access the object.

I really shot myself in the foot by not documenting this the first time, so I added explanatory comments. Haha.

This made the live preview unpredictable and unstable. The fact that it was inside a Python thread which was inside a QThread might not have helped. Python threads are pretty bad so I have to do some benchmarking to see if re-introducing the Python thread makes sense.

In this pull request I've also added a `--no-preview` commandline option. Exporting video will be faster without any preview, so it's worth including.