### PR TITLE
Remove Python threads during video export

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,7 +3,7 @@ import os
 import logging
 
 
-__version__ = '2.0.0-b1'
+__version__ = '2.0.0-b2'
 
 
 class Logger(logging.getLoggerClass()):

--- a/src/toolkit/ffmpeg.py
+++ b/src/toolkit/ffmpeg.py
@@ -392,7 +392,7 @@ def getAudioDuration(filename):
         fileInfo = checkOutput(command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as ex:
         fileInfo = ex.output
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         # ffmpeg is possibly not installed
         return False
 

--- a/src/video_thread.py
+++ b/src/video_thread.py
@@ -108,7 +108,6 @@ class Worker(QtCore.QObject):
         # or else Qt will garbage-collect it on the C++ side
         self.latestPreview = ImageQt(frame)
         self.imageCreated.emit(QtGui.QImage(self.latestPreview))
-        self.lastPreview = time.time()
 
     @pyqtSlot()
     def createVideo(self):
@@ -265,9 +264,6 @@ class Worker(QtCore.QObject):
         # START CREATING THE VIDEO
         # =~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~==~=~=~=~=~=~=~=~=~=~=~=~=~=~
 
-        # Last time preview was drawn
-        self.lastPreview = time.time()
-
         # Begin piping into ffmpeg!
         progressBarValue = 0
         self.progressBarUpdate.emit(progressBarValue)
@@ -279,7 +275,7 @@ class Worker(QtCore.QObject):
             frame = self.renderFrame(audioI)
 
             # Update live preview
-            if self.previewEnabled and time.time() - self.lastPreview > 0.5:
+            if self.previewEnabled:
                 self.showPreview(frame)
 
             try:


### PR DESCRIPTION
The Python threads made the code a lot more confusing, didn't really provide much speed, and caused the memory usage to be unstable. This was another cause of random crashes, so I bumped the version number and I'll probably make another Release soon after further testing.

I also "refactored" the `video_thread.py` code a bit while I was in there, to break it up into smaller methods. Hopefully it's a bit easier to understand without introducing new bugs. Like I said, it still needs further testing :) But it seems more stable than current master