### PR TITLE
Relax test comparison

### DIFF
--- a/tests/test_comp_spectrum.py
+++ b/tests/test_comp_spectrum.py
@@ -1,6 +1,6 @@
 from avp.command import Command
 from pytestqt import qtbot
-from pytest import fixture
+from pytest import fixture, approx
 from . import (
     imageDataSum,
     command,
@@ -21,7 +21,10 @@ def coreWithSpectrumComp(qtbot, command):
 def test_comp_spectrum_previewRender(coreWithSpectrumComp):
     comp = coreWithSpectrumComp.selectedComponents[0]
     image = comp.previewRender()
-    assert imageDataSum(image) == 71992628
+
+    accept_range = 719 #  Accept images with ±0.001% difference
+    expected = 71992628 #  This value was extracted on amd64
+    assert imageDataSum(image) == approx(expected, abs=accept_range)
 
 
 def test_comp_spectrum_renderFrame(coreWithSpectrumComp, audioData):


### PR DESCRIPTION
The test that breaks in i686 and arm64 is summing image data, which can have small differences between platforms.

The current relaxation will accept comparisons that differ in 0.001%, so that when the test is run on different platforms it has the chance to pass.

Fixes #100